### PR TITLE
feat: WebSocket 인증(핸드셰이크 단계) 추가 + JwtUtil 활용한 JwtHandshakeInterceptor…

### DIFF
--- a/src/main/java/team/budderz/buddyspace/global/security/JwtHandshakeInterceptor.java
+++ b/src/main/java/team/budderz/buddyspace/global/security/JwtHandshakeInterceptor.java
@@ -1,0 +1,56 @@
+package team.budderz.buddyspace.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+// WebSocket 연결(핸드셰이크) 요청이 들어올 때 JWT 토큰을 검증해서 인증된 사용자만 WebSocket 연결 허용
+// 인증된 사용자의 정보를 WebSocket 세션에 저장 → 이후 채팅 메시지 처리 시 활용 가능
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtHandshakeInterceptor(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+
+        // WebSocket 연결 요청이 Servlet 기반 HTTP 요청인지 확인
+        // 이유: HttpServletRequest 에서 헤더를 읽으려고 하기 때문 + Spring WebSocket 지원 구조 때문
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            // 원본 HttpServletRequest 꺼내오기
+            HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
+
+            // JWT 토큰 추출 (Authorization 헤더에서 Bearer 토큰 가져오기)
+            String token = jwtUtil.extractToken(httpServletRequest);
+
+            // 토큰이 존재하고, 유효한지, 그리고 ACCESS 토큰인지 확인
+            if (token != null && jwtUtil.validateToken(token) && jwtUtil.isAccessToken(token)) {
+                // 인증 성공 → 사용자 정보(UserAuth)를 WebSocket 세션에 저장
+                attributes.put("userAuth", jwtUtil.extractUserAuth(token));
+                return true; // → WebSocket 연결 허용
+            } else {
+                // 인증 실패 → WebSocket 연결 거부
+                return false;
+            }
+        }
+        // Servlet 기반 요청이 아니면 거부
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        // 아무것도 안 해도 됨
+        // afterHandshake 는 지금은 별도 로직 필요 없음 (빈 메서드)
+    }
+
+}

--- a/src/main/java/team/budderz/buddyspace/infra/config/WebSocketConfig.java
+++ b/src/main/java/team/budderz/buddyspace/infra/config/WebSocketConfig.java
@@ -1,20 +1,29 @@
 package team.budderz.buddyspace.infra.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import team.budderz.buddyspace.global.security.JwtHandshakeInterceptor;
+import team.budderz.buddyspace.global.security.JwtUtil;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtUtil jwtUtil;
 
     /* 클라이언트가 최초로 WebSocket 연결을 시도할 때 접속할 엔드포인트 설정 */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 	서버 내부 엔드포인트 경로 설정 + CORS 설정 + SockJS 프로토콜 지원 추가 (fallback)
-        registry.addEndpoint("/ws").setAllowedOrigins("*").withSockJS();
+        registry.addEndpoint("/ws")
+                .addInterceptors(new JwtHandshakeInterceptor(jwtUtil)) // 핸드셰이크 단계에서 JWT 토큰을 검증해서 인증된 사용자만 WebSocket 연결을 허용
+                .setAllowedOrigins("*")
+                .withSockJS();
     }
 
     /* STOMP 메시지 라우팅 규칙 설정 */


### PR DESCRIPTION
Feat(chat): WebSocket 핸드셰이크 단계에서 JWT 인증 인터셉터 적용 #42

<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!-- Resolves: #(Issue Number) -->
resolves #42
close #42

## 📌 개요
WebSocket 핸드셰이크 단계에서 JwtHandshakeInterceptor를 적용하여
인증된 사용자만 WebSocket 연결을 허용하도록 변경하였습니다.

- WebSocket 인증(핸드셰이크 단계) 추가
- JwtUtil 활용한 JwtHandshakeInterceptor 적용
- WebSocketConfig 수정 → 인증 인터셉터 추가

## 📝 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (설명 필요)

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. (Commit message convention 참고)
- [x] 변경 사항에 대한 테스트를 했습니다. (기능 테스트 진행 완료)

## 🗨️ 팀원에게 전할 말
- 실시간 채팅 기능 개발을 위한 기초 작업입니다.
- 클라이언트에서 WebSocket 연결 시 JWT 토큰을 반드시 헤더에 포함하도록 연동 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- WebSocket 연결 시 JWT 인증이 적용되어, 인증된 사용자만 WebSocket에 접속할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->