### PR TITLE
Feat/#53 group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/team/budderz/buddyspace/api/group/controller/GroupController.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/controller/GroupController.java
@@ -4,12 +4,20 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import team.budderz.buddyspace.api.group.request.GroupRequest;
+import team.budderz.buddyspace.api.group.request.SaveGroupRequest;
+import team.budderz.buddyspace.api.group.request.UpdateGroupRequest;
+import team.budderz.buddyspace.api.group.response.GroupListResponse;
 import team.budderz.buddyspace.api.group.response.GroupResponse;
 import team.budderz.buddyspace.domain.group.service.GroupService;
 import team.budderz.buddyspace.global.response.BaseResponse;
 import team.budderz.buddyspace.global.security.UserAuth;
+import team.budderz.buddyspace.infra.database.group.entity.GroupSortType;
 
+import java.util.List;
+
+/**
+ * 모임 기본 CRUD
+ */
 @RestController
 @RequestMapping("/api/groups")
 @RequiredArgsConstructor
@@ -18,7 +26,7 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping
-    public BaseResponse<GroupResponse> saveGroup(@RequestBody @Valid GroupRequest request,
+    public BaseResponse<GroupResponse> saveGroup(@RequestBody @Valid SaveGroupRequest request,
                                                  @AuthenticationPrincipal UserAuth userAuth) {
         Long loginUserId = userAuth.getUserId();
         GroupResponse response = groupService.saveGroup(
@@ -34,7 +42,7 @@ public class GroupController {
     }
 
     @PutMapping("/{groupId}")
-    public BaseResponse<GroupResponse> updateGroup(@RequestBody @Valid GroupRequest request,
+    public BaseResponse<GroupResponse> updateGroup(@RequestBody @Valid UpdateGroupRequest request,
                                                    @PathVariable Long groupId,
                                                    @AuthenticationPrincipal UserAuth userAuth) {
         Long loginUserId = userAuth.getUserId();
@@ -42,6 +50,7 @@ public class GroupController {
                 loginUserId,
                 groupId,
                 request.name(),
+                request.description(),
                 request.coverImageUrl(),
                 request.access(),
                 request.type(),
@@ -58,5 +67,31 @@ public class GroupController {
         groupService.deleteGroup(loginUserId, groupId);
 
         return new BaseResponse<>(null);
+    }
+
+    @GetMapping("/user")
+    public BaseResponse<List<GroupListResponse>> findGroupsByUser(@AuthenticationPrincipal UserAuth userAuth) {
+        Long loginUserId = userAuth.getUserId();
+        List<GroupListResponse> responses = groupService.findGroupsByUser(loginUserId);
+
+        return new BaseResponse<>(responses);
+    }
+
+    @GetMapping("/on")
+    public BaseResponse<List<GroupListResponse>> findOnlineGroups(@RequestParam String sort) {
+        GroupSortType sortType = GroupSortType.from(sort);
+        List<GroupListResponse> responses = groupService.findOnlineGroups(sortType);
+
+        return new BaseResponse<>(responses);
+    }
+
+    @GetMapping("/off")
+    public BaseResponse<List<GroupListResponse>> findOfflineGroups(@AuthenticationPrincipal UserAuth userAuth,
+                                                                   @RequestParam String sort) {
+        Long loginUserId = userAuth.getUserId();
+        GroupSortType sortType = GroupSortType.from(sort);
+        List<GroupListResponse> responses = groupService.findOfflineGroups(loginUserId, sortType);
+
+        return new BaseResponse<>(responses);
     }
 }

--- a/src/main/java/team/budderz/buddyspace/api/group/request/SaveGroupRequest.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/request/SaveGroupRequest.java
@@ -8,9 +8,9 @@ import team.budderz.buddyspace.infra.database.group.entity.GroupType;
 import team.budderz.buddyspace.infra.database.group.entity.GroupInterest;
 
 /**
- * 모임 생성/수정 요청 DTO
+ * 모임 생성 요청 DTO
  */
-public record GroupRequest(
+public record SaveGroupRequest(
 
         /**
          * 모임 이름 (필수, 최대 20자)
@@ -19,6 +19,9 @@ public record GroupRequest(
         @Size(max = 20, message = "모임 이름은 20자를 초과할 수 없습니다.")
         String name,
 
+        /**
+         * 모임 커버 이미지 주소 (선택)
+         */
         String coverImageUrl,
 
         /**

--- a/src/main/java/team/budderz/buddyspace/api/group/request/UpdateGroupRequest.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/request/UpdateGroupRequest.java
@@ -1,0 +1,47 @@
+package team.budderz.buddyspace.api.group.request;
+
+import jakarta.validation.constraints.Size;
+import team.budderz.buddyspace.infra.database.group.entity.GroupAccess;
+import team.budderz.buddyspace.infra.database.group.entity.GroupInterest;
+import team.budderz.buddyspace.infra.database.group.entity.GroupType;
+
+/**
+ * 모임 수정 요청 DTO
+ */
+public record UpdateGroupRequest(
+
+        /**
+         * 모임 이름
+         */
+        @Size(max = 20, message = "모임 이름은 20자를 초과할 수 없습니다.")
+        String name,
+
+        /**
+         * 모임 커버 이미지 주소
+         */
+        String coverImageUrl,
+
+        /**
+         * 모임 소개글
+         */
+        @Size(max = 200, message = "모임 소개는 200자를 초과할 수 없습니다.")
+        String description,
+
+        /**
+         * 모임 공개 여부 (GroupAccess Enum)
+         * - PUBLIC, PRIVATE
+         */
+        GroupAccess access,
+
+        /**
+         * 모임 유형 (GroupType Enum)
+         * - ONLINE, OFFLINE, HYBRID
+         */
+        GroupType type,
+
+        /**
+         * 모임 관심사 (GroupInterest Enum)
+         * - HOBBY, FAMILY, SCHOOL, BUSINESS, EXERCISE, GAME, STUDY, FAN, OTHER
+         */
+        GroupInterest interest
+) {}

--- a/src/main/java/team/budderz/buddyspace/api/group/response/GroupListResponse.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/response/GroupListResponse.java
@@ -1,0 +1,17 @@
+package team.budderz.buddyspace.api.group.response;
+
+import team.budderz.buddyspace.infra.database.group.entity.GroupInterest;
+import team.budderz.buddyspace.infra.database.group.entity.GroupType;
+
+/**
+ * 모임 목록 조회 응답 DTO
+ */
+public record GroupListResponse(
+        Long groupId,
+        String groupName,
+        String groupDescription,
+        String groupCoverImageUrl,
+        GroupType groupType,
+        GroupInterest groupInterest,
+        Long memberCount
+) {}

--- a/src/main/java/team/budderz/buddyspace/api/group/response/GroupResponse.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/response/GroupResponse.java
@@ -11,6 +11,7 @@ import team.budderz.buddyspace.infra.database.group.entity.GroupType;
 public record GroupResponse(
         Long groupId,
         String groupName,
+        String groupDescription,
         String groupCoverImageUrl,
         GroupAccess groupAccess,
         GroupType groupType,
@@ -20,6 +21,7 @@ public record GroupResponse(
         return new GroupResponse(
                 group.getId(),
                 group.getName(),
+                group.getDescription(),
                 group.getCoverImageUrl(),
                 group.getAccess(),
                 group.getType(),

--- a/src/main/java/team/budderz/buddyspace/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/team/budderz/buddyspace/domain/group/exception/GroupErrorCode.java
@@ -10,10 +10,12 @@ import team.budderz.buddyspace.global.response.ErrorCode;
 public enum GroupErrorCode implements ErrorCode {
 
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "G001", "해당 모임을 찾을 수 없습니다."),
+    NEIGHBORHOOD_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "N001", "해당 사용자의 동네 정보를 찾을 수 없습니다."),
     GROUP_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "G002", "모임 유형을 찾을 수 없습니다."),
     INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "G003", "모임 유형을 찾을 수 없습니다."),
-    FUNCTION_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "G004", "해당 기능에 대한 접근 권한이 없습니다."),
-    MEMBERS_EXIST_IN_GROUP(HttpStatus.BAD_REQUEST.value(), "G005", "멤버가 존재하는 모임은 삭제할 수 없습니다.");
+    INVALID_GROUP_SORT_TYPE(HttpStatus.NOT_FOUND.value(), "G004", "지원하지 않는 정렬 방식입니다."),
+    FUNCTION_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "G005", "해당 기능에 대한 접근 권한이 없습니다."),
+    MEMBERS_EXIST_IN_GROUP(HttpStatus.BAD_REQUEST.value(), "G006", "멤버가 존재하는 모임은 삭제할 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/team/budderz/buddyspace/infra/config/QuerydslConfig.java
+++ b/src/main/java/team/budderz/buddyspace/infra/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package team.budderz.buddyspace.infra.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/entity/Group.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/entity/Group.java
@@ -1,5 +1,6 @@
 package team.budderz.buddyspace.infra.database.group.entity;
 
+import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -65,14 +66,17 @@ public class Group extends BaseEntity {
     }
 
     public void updateGroupInfo(String name,
+                                String description,
                                 String coverImageUrl,
                                 GroupAccess access,
                                 GroupType type,
                                 GroupInterest interest) {
-        this.name = name;
-        this.coverImageUrl = coverImageUrl;
-        this.access = access;
-        this.type = type;
-        this.interest = interest;
+
+        if (!StringUtils.isBlank(name)) this.name = name;
+        if (!StringUtils.isBlank(description)) this.description = description;
+        if (!StringUtils.isBlank(coverImageUrl)) this.coverImageUrl = coverImageUrl;
+        if (access != null) this.access = access;
+        if (type != null) this.type = type;
+        if (interest != null) this.interest = interest;
     }
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/entity/GroupSortType.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/entity/GroupSortType.java
@@ -10,6 +10,9 @@ public enum GroupSortType {
     LATEST;
 
     public static GroupSortType from(String value) {
+        if (value == null) {
+            throw new GroupException(GroupErrorCode.INVALID_GROUP_SORT_TYPE);
+        }
         return Arrays.stream(values())
                 .filter(e -> e.name().equalsIgnoreCase(value))
                 .findFirst()

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/entity/GroupSortType.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/entity/GroupSortType.java
@@ -1,0 +1,18 @@
+package team.budderz.buddyspace.infra.database.group.entity;
+
+import team.budderz.buddyspace.domain.group.exception.GroupErrorCode;
+import team.budderz.buddyspace.domain.group.exception.GroupException;
+
+import java.util.Arrays;
+
+public enum GroupSortType {
+    POPULAR,
+    LATEST;
+
+    public static GroupSortType from(String value) {
+        return Arrays.stream(values())
+                .filter(e -> e.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVALID_GROUP_SORT_TYPE));
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupQueryRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupQueryRepository.java
@@ -1,0 +1,16 @@
+package team.budderz.buddyspace.infra.database.group.repository;
+
+import team.budderz.buddyspace.api.group.response.GroupListResponse;
+import team.budderz.buddyspace.infra.database.group.entity.GroupSortType;
+import team.budderz.buddyspace.infra.database.neighborhood.entity.Neighborhood;
+
+import java.util.List;
+
+public interface GroupQueryRepository {
+
+    List<GroupListResponse> findGroupsByUser(Long userId);
+
+    List<GroupListResponse> findOnlineGroups(GroupSortType sortType);
+
+    List<GroupListResponse> findOfflineGroups(Neighborhood neighborhood, GroupSortType sortType);
+}

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupRepository.java
@@ -3,5 +3,5 @@ package team.budderz.buddyspace.infra.database.group.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.budderz.buddyspace.infra.database.group.entity.Group;
 
-public interface GroupRepository extends JpaRepository<Group, Long> {
+public interface GroupRepository extends JpaRepository<Group, Long>, GroupQueryRepository {
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupRepositoryImpl.java
@@ -1,0 +1,106 @@
+package team.budderz.buddyspace.infra.database.group.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.budderz.buddyspace.api.group.response.GroupListResponse;
+import team.budderz.buddyspace.infra.database.group.entity.GroupAccess;
+import team.budderz.buddyspace.infra.database.group.entity.GroupSortType;
+import team.budderz.buddyspace.infra.database.group.entity.GroupType;
+import team.budderz.buddyspace.infra.database.group.entity.QGroup;
+import team.budderz.buddyspace.infra.database.membership.entity.JoinStatus;
+import team.budderz.buddyspace.infra.database.membership.entity.QMembership;
+import team.budderz.buddyspace.infra.database.neighborhood.entity.Neighborhood;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupRepositoryImpl implements GroupQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private static final long GROUP_FETCH_LIMIT = 100L;
+
+    @Override
+    public List<GroupListResponse> findGroupsByUser(Long userId) {
+        QGroup group = QGroup.group;
+        QMembership membership = QMembership.membership;
+
+        return queryFactory
+                .select(Projections.constructor(GroupListResponse.class,
+                        group.id,
+                        group.name,
+                        group.description,
+                        group.coverImageUrl,
+                        group.type,
+                        group.interest,
+                        membership.id.count().as("memberCount")
+                ))
+                .from(group)
+                .join(membership).on(
+                        membership.group.eq(group),
+                        membership.user.id.eq(userId),
+                        membership.joinStatus.eq(JoinStatus.APPROVED)
+                )
+                .groupBy(group.id, membership.joinedAt)
+                .orderBy(membership.joinedAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<GroupListResponse> findOnlineGroups(GroupSortType sortType) {
+        return findGroupsByCondition(Set.of(GroupType.ONLINE, GroupType.HYBRID), null, sortType);
+    }
+
+    @Override
+    public List<GroupListResponse> findOfflineGroups(Neighborhood neighborhood, GroupSortType sortType) {
+        return findGroupsByCondition(Set.of(GroupType.OFFLINE, GroupType.HYBRID), neighborhood, sortType);
+    }
+
+    private List<GroupListResponse> findGroupsByCondition(Set<GroupType> groupTypes,
+                                                          @Nullable Neighborhood neighborhood,
+                                                          GroupSortType sortType) {
+        QGroup group = QGroup.group;
+        QMembership membership = QMembership.membership;
+
+        BooleanBuilder conditions = new BooleanBuilder();
+
+        conditions.and(group.type.in(groupTypes));
+        conditions.and(group.access.eq(GroupAccess.PUBLIC));
+
+        if (neighborhood != null) {
+            conditions.and(group.neighborhood.eq(neighborhood));
+        }
+
+        JPAQuery<GroupListResponse> query = queryFactory
+                .select(Projections.constructor(GroupListResponse.class,
+                        group.id,
+                        group.name,
+                        group.description,
+                        group.coverImageUrl,
+                        group.type,
+                        group.interest,
+                        membership.id.count().as("memberCount")
+                ))
+                .from(group)
+                .leftJoin(membership).on(
+                        membership.group.eq(group)
+                                .and(membership.joinStatus.eq(JoinStatus.APPROVED))
+                )
+                .where(conditions)
+                .groupBy(group.id);
+
+        if (sortType == GroupSortType.POPULAR) {
+            query.orderBy(membership.id.count().desc());
+        } else {
+            query.orderBy(group.createdAt.desc());
+        }
+
+        return query.limit(GROUP_FETCH_LIMIT).fetch();
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupRepositoryImpl.java
@@ -1,6 +1,7 @@
 package team.budderz.buddyspace.infra.database.group.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,8 +17,8 @@ import team.budderz.buddyspace.infra.database.membership.entity.JoinStatus;
 import team.budderz.buddyspace.infra.database.membership.entity.QMembership;
 import team.budderz.buddyspace.infra.database.neighborhood.entity.Neighborhood;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -31,25 +32,68 @@ public class GroupRepositoryImpl implements GroupQueryRepository {
         QGroup group = QGroup.group;
         QMembership membership = QMembership.membership;
 
-        return queryFactory
-                .select(Projections.constructor(GroupListResponse.class,
+        List<Tuple> joined = queryFactory
+                .select(
                         group.id,
                         group.name,
                         group.description,
                         group.coverImageUrl,
                         group.type,
                         group.interest,
-                        membership.id.count().as("memberCount")
-                ))
+                        membership.joinedAt
+                )
                 .from(group)
                 .join(membership).on(
                         membership.group.eq(group),
                         membership.user.id.eq(userId),
                         membership.joinStatus.eq(JoinStatus.APPROVED)
                 )
-                .groupBy(group.id, membership.joinedAt)
-                .orderBy(membership.joinedAt.desc())
+                .orderBy(membership.joinedAt.asc())
                 .fetch();
+
+        List<Long> groupIds = joined.stream()
+                .map(tuple -> tuple.get(group.id))
+                .toList();
+
+        if (groupIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Tuple> counts = queryFactory
+                .select(
+                        membership.group.id,
+                        membership.id.count()
+                )
+                .from(membership)
+                .where(
+                        membership.joinStatus.eq(JoinStatus.APPROVED)
+                                .and(membership.group.id.in(groupIds))
+                )
+                .groupBy(membership.group.id)
+                .fetch();
+
+        Map<Long, Long> memberCounts = counts.stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(membership.group.id),
+                        tuple -> tuple.get(membership.id.count())
+                ));
+
+        List<GroupListResponse> result = new ArrayList<>();
+
+        for (Tuple t : joined) {
+            Long groupId = t.get(group.id);
+            result.add(new GroupListResponse(
+                    groupId,
+                    t.get(group.name),
+                    t.get(group.description),
+                    t.get(group.coverImageUrl),
+                    t.get(group.type),
+                    t.get(group.interest),
+                    memberCounts.getOrDefault(groupId, 0L)
+            ));
+        }
+
+        return result;
     }
 
     @Override


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #53 
close #53 
## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
내 모임 목록 조회 기능 구현
온라인 모임 목록 조회 기능 구현
오프라인 모임 목록 조회 기능 구현
## 📝 PR 유형
기능 구현
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
오프라인 모임 목록 조회는 동네 기능 구현 후 테스트 예정입니다.
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 가입한 그룹 목록, 온라인 그룹(정렬 지원), 오프라인 그룹(정렬 및 동네 기반) 조회 기능이 추가되었습니다.
  - 그룹 목록 조회 시 그룹명, 설명, 커버 이미지, 유형, 관심사, 멤버 수 등의 정보가 제공됩니다.
  - 그룹 생성 및 수정 요청 시 커버 이미지 URL과 설명 필드가 추가되었습니다.

- **기능 개선**
  - 그룹 수정 시 입력값이 비어 있거나 null일 경우 기존 값을 유지하도록 개선되었습니다.
  - 그룹 상세 응답에 그룹 설명이 포함됩니다.

- **오류 코드**
  - 잘못된 그룹 정렬 방식, 동네 정보 없음 등에 대한 오류 코드가 추가되었습니다.

- **기술 개선**
  - 고급 쿼리 기능(QueryDSL) 및 정렬 타입(enum) 지원이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->