### PR TITLE
Feat/#64 group: 모임 이름 검색 기능 구현

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/group/controller/GroupController.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/controller/GroupController.java
@@ -10,10 +10,9 @@ import team.budderz.buddyspace.api.group.response.GroupListResponse;
 import team.budderz.buddyspace.api.group.response.GroupResponse;
 import team.budderz.buddyspace.domain.group.service.GroupService;
 import team.budderz.buddyspace.global.response.BaseResponse;
+import team.budderz.buddyspace.global.response.PageResponse;
 import team.budderz.buddyspace.global.security.UserAuth;
 import team.budderz.buddyspace.infra.database.group.entity.GroupSortType;
-
-import java.util.List;
 
 /**
  * 모임 기본 CRUD
@@ -69,28 +68,51 @@ public class GroupController {
         return new BaseResponse<>(null);
     }
 
-    @GetMapping("/user")
-    public BaseResponse<List<GroupListResponse>> findGroupsByUser(@AuthenticationPrincipal UserAuth userAuth) {
+    @GetMapping("/my")
+    public BaseResponse<PageResponse<GroupListResponse>> findGroupsByUser(
+            @AuthenticationPrincipal UserAuth userAuth,
+            @RequestParam(defaultValue = "0") int page
+
+    ) {
         Long loginUserId = userAuth.getUserId();
-        List<GroupListResponse> responses = groupService.findGroupsByUser(loginUserId);
+        PageResponse<GroupListResponse> responses = groupService.findGroupsByUser(loginUserId, page);
 
         return new BaseResponse<>(responses);
     }
 
     @GetMapping("/on")
-    public BaseResponse<List<GroupListResponse>> findOnlineGroups(@RequestParam String sort) {
+    public BaseResponse<PageResponse<GroupListResponse>> findOnlineGroups(
+            @RequestParam String sort,
+            @RequestParam(required = false) String interest,
+            @RequestParam(defaultValue = "0") int page
+    ) {
         GroupSortType sortType = GroupSortType.from(sort);
-        List<GroupListResponse> responses = groupService.findOnlineGroups(sortType);
+        PageResponse<GroupListResponse> responses = groupService.findOnlineGroups(sortType, interest, page);
 
         return new BaseResponse<>(responses);
     }
 
     @GetMapping("/off")
-    public BaseResponse<List<GroupListResponse>> findOfflineGroups(@AuthenticationPrincipal UserAuth userAuth,
-                                                                   @RequestParam String sort) {
+    public BaseResponse<PageResponse<GroupListResponse>> findOfflineGroups(
+            @AuthenticationPrincipal UserAuth userAuth,
+            @RequestParam String sort,
+            @RequestParam(required = false) String interest,
+            @RequestParam(defaultValue = "0") int page
+    ) {
         Long loginUserId = userAuth.getUserId();
         GroupSortType sortType = GroupSortType.from(sort);
-        List<GroupListResponse> responses = groupService.findOfflineGroups(loginUserId, sortType);
+        PageResponse<GroupListResponse> responses = groupService.findOfflineGroups(loginUserId, sortType, interest, page);
+
+        return new BaseResponse<>(responses);
+    }
+
+    @GetMapping("/search")
+    public BaseResponse<PageResponse<GroupListResponse>> searchGroupsByName(
+            @RequestParam String keyword,
+            @RequestParam(required = false) String interest,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        PageResponse<GroupListResponse> responses = groupService.searchGroupsByName(keyword, interest, page);
 
         return new BaseResponse<>(responses);
     }

--- a/src/main/java/team/budderz/buddyspace/domain/group/constant/GroupDefaults.java
+++ b/src/main/java/team/budderz/buddyspace/domain/group/constant/GroupDefaults.java
@@ -4,6 +4,10 @@ public final class GroupDefaults {
 
     private GroupDefaults() {}
 
+    public static final String DEFAULT_INVITE_BASE_URL = "http://localhost:8080/api/invites?code="; // 테스트용
+
+    public static final int DEFAULT_PAGE_SIZE = 100;
+
     public static final String DEFAULT_ONLINE_GROUP_COVER_IMAGE_URL = "https://raw.githubusercontent.com/withong/my-storage/main/budderz/icon-online-group.png";
     public static final String DEFAULT_OFFLINE_GROUP_COVER_IMAGE_URL = "https://raw.githubusercontent.com/withong/my-storage/main/budderz/icon-offline-group.png";
     public static final String DEFAULT_HYBRID_GROUP_COVER_IMAGE_URL = "https://raw.githubusercontent.com/withong/my-storage/main/budderz/icon-hybrid-group.png";

--- a/src/main/java/team/budderz/buddyspace/domain/group/service/GroupInviteService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/group/service/GroupInviteService.java
@@ -9,11 +9,12 @@ import team.budderz.buddyspace.domain.group.validator.GroupValidator;
 import team.budderz.buddyspace.infra.database.group.entity.Group;
 import team.budderz.buddyspace.infra.database.group.entity.PermissionType;
 
+import static team.budderz.buddyspace.domain.group.constant.GroupDefaults.*;
+
 @Service
 @RequiredArgsConstructor
 public class GroupInviteService {
 
-    private static final String INVITE_BASE_URL = "https://budderz.kr/invite/";
     private final GroupValidator validator;
 
     @Transactional
@@ -22,7 +23,7 @@ public class GroupInviteService {
         Group group = validator.findGroupOrThrow(groupId);
 
         if (group.getInviteCode() != null) {
-            return GroupInviteResponse.of(group, INVITE_BASE_URL + group.getInviteCode());
+            return GroupInviteResponse.of(group, DEFAULT_INVITE_BASE_URL + group.getInviteCode());
         }
 
         String code;
@@ -32,7 +33,7 @@ public class GroupInviteService {
 
         group.updateInviteCode(code);
 
-        return GroupInviteResponse.of(group, INVITE_BASE_URL + code);
+        return GroupInviteResponse.of(group, DEFAULT_INVITE_BASE_URL + code);
     }
 
     @Transactional(readOnly = true)
@@ -40,7 +41,7 @@ public class GroupInviteService {
         validator.validateLeader(loginUserId, groupId);
         Group group = validator.findGroupOrThrow(groupId);
 
-        String inviteLink = group.getInviteCode() == null ? null : INVITE_BASE_URL + group.getInviteCode();
+        String inviteLink = group.getInviteCode() == null ? null : DEFAULT_INVITE_BASE_URL + group.getInviteCode();
 
         return GroupInviteResponse.of(group, inviteLink);
     }

--- a/src/main/java/team/budderz/buddyspace/domain/membership/service/MembershipService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/membership/service/MembershipService.java
@@ -41,6 +41,7 @@ public class MembershipService {
         User user = findUserById(userId);
         Group group = validator.findGroupOrThrow(groupId);
 
+        // 이미 가입 요청/승인 중이거나 차단된 회원일 경우 예외
         membershipRepository.findByUser_IdAndGroup_Id(userId, groupId).ifPresent(membership -> {
             if (membership.getJoinStatus() == JoinStatus.REQUESTED) {
                 throw new MembershipException(MembershipErrorCode.ALREADY_REQUESTED);

--- a/src/main/java/team/budderz/buddyspace/global/response/PageResponse.java
+++ b/src/main/java/team/budderz/buddyspace/global/response/PageResponse.java
@@ -1,0 +1,69 @@
+package team.budderz.buddyspace.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 페이징 응답 공통 DTO
+ * @param <T> 응답 content로 포함될 객체 타입
+ */
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+
+    /**
+     * 현재 페이지에 포함될 데이터 목록
+     */
+    private List<T> content;
+
+    /**
+     * 현재 페이지 번호 (0부터 시작)
+     */
+    private int pageNumber;
+
+    /**
+     * 한 페이지에 포함될 항목 개수
+     */
+    private int pageSize;
+
+    /**
+     * 전체 데이터 개수
+     */
+    private long totalElements;
+
+    /**
+     * 전체 페이지 개수
+     */
+    private int totalPages;
+
+    /**
+     * 현재 페이지가 첫 번째 페이지인지 여부
+     */
+    private boolean first;
+
+    /**
+     * 현재 페이지가 마지막 페이지인지 여부
+     */
+    private boolean last;
+
+    /**
+     * 현재 페이지가 비어 있는지 여부
+     */
+    private boolean empty;
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast(),
+                page.isEmpty()
+        );
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/infra/database/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/chat/repository/ChatRoomRepository.java
@@ -21,4 +21,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         """)
     List<ChatRoom> findDirectRoomByParticipants(@Param("participantIds") List<Long> participantIds,
                                                 @Param("size") long size);
+
+    void deleteAllByGroup_Id(Long groupId);
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/entity/GroupInterest.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/entity/GroupInterest.java
@@ -3,6 +3,8 @@ package team.budderz.buddyspace.infra.database.group.entity;
 import team.budderz.buddyspace.domain.group.exception.GroupErrorCode;
 import team.budderz.buddyspace.domain.group.exception.GroupException;
 
+import java.util.Arrays;
+
 /**
  * 모임 관심사
  */
@@ -23,12 +25,22 @@ public enum GroupInterest {
         this.label = label;
     }
 
-    public static GroupInterest from(String label) {
+    public static GroupInterest fromLabel(String label) {
         for (GroupInterest interest : GroupInterest.values()) {
             if (interest.label.equals(label)) {
                 return interest;
             }
         }
         throw new GroupException(GroupErrorCode.INTEREST_NOT_FOUND);
+    }
+
+    public static GroupInterest fromName(String name) {
+        if (name == null) {
+            throw new GroupException(GroupErrorCode.INTEREST_NOT_FOUND);
+        }
+        return Arrays.stream(values())
+                .filter(e -> e.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INTEREST_NOT_FOUND));
     }
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupQueryRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/group/repository/GroupQueryRepository.java
@@ -1,16 +1,19 @@
 package team.budderz.buddyspace.infra.database.group.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import team.budderz.buddyspace.api.group.response.GroupListResponse;
+import team.budderz.buddyspace.infra.database.group.entity.GroupInterest;
 import team.budderz.buddyspace.infra.database.group.entity.GroupSortType;
 import team.budderz.buddyspace.infra.database.neighborhood.entity.Neighborhood;
 
-import java.util.List;
-
 public interface GroupQueryRepository {
 
-    List<GroupListResponse> findGroupsByUser(Long userId);
+    Page<GroupListResponse> findGroupsByUser(Long userId, Pageable pageable);
 
-    List<GroupListResponse> findOnlineGroups(GroupSortType sortType);
+    Page<GroupListResponse> findOnlineGroups(GroupSortType sortType, GroupInterest interest, Pageable pageable);
 
-    List<GroupListResponse> findOfflineGroups(Neighborhood neighborhood, GroupSortType sortType);
+    Page<GroupListResponse> findOfflineGroups(Neighborhood neighborhood, GroupSortType sortType, GroupInterest interest, Pageable pageable);
+
+    Page<GroupListResponse> searchGroupsByName(String keyword, GroupInterest interest, Pageable pageable);
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/mission/repository/MissionRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/mission/repository/MissionRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team.budderz.buddyspace.infra.database.mission.entity.Mission;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
+
+    void deleteAllByGroup_Id(Long groupId);
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/post/repository/PostRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/post/repository/PostRepository.java
@@ -1,7 +1,6 @@
 package team.budderz.buddyspace.infra.database.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import team.budderz.buddyspace.infra.database.comment.entity.Comment;
 import team.budderz.buddyspace.infra.database.post.entity.Post;
 
 import java.util.List;
@@ -12,4 +11,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByGroupIdOrderByCreatedAtDesc(Long groupId);
 
     List<Post> findByGroupIdAndIsNoticeTrueOrderByCreatedAtDesc(Long groupId);
+
+    void deleteAllByGroup_Id(Long groupId);
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/schedule/repository/ScheduleRepository.java
@@ -1,12 +1,11 @@
 package team.budderz.buddyspace.infra.database.schedule.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
 import team.budderz.buddyspace.infra.database.schedule.entity.Schedule;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 	@Query(""" 
@@ -18,4 +17,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 		"""
 	)
 	List<Schedule> findAllByMonth(Long groupId, LocalDateTime monthStart, LocalDateTime monthEnd);
+
+	void deleteAllByGroup_Id(Long groupId);
 }

--- a/src/main/java/team/budderz/buddyspace/infra/database/vote/repository/VoteRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/vote/repository/VoteRepository.java
@@ -1,11 +1,12 @@
 package team.budderz.buddyspace.infra.database.vote.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import team.budderz.buddyspace.infra.database.vote.entity.Vote;
+
+import java.util.List;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 	List<Vote> findByGroupIdOrderByCreatedAtDesc(Long groupId);
+
+	void deleteAllByGroup_Id(Long groupId);
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #64 
close #64 
## 📌 개요
> 모임 이름 검색 기능 구현
> 온라인/오프라인 모임 검색 리팩토링
## 📝 PR 유형
기능 구현
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
모임 초대 링크별 가입한 회원 목록 조회 기능은, 
모임당 초대 링크가 단 하나만 존재하는 상황이라 필요한 기능일지 의문이 들어서 우선 구현 보류했습니다.

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 그룹 목록 조회, 온라인/오프라인 그룹 조회, 그룹 검색 API에 페이지네이션(페이징) 및 관심사 필터 기능이 추가되었습니다.
  - 그룹 이름으로 검색하는 엔드포인트가 새로 추가되었습니다.

- **개선 사항**
  - 그룹 삭제 시 그룹과 연관된 게시글, 미션, 투표, 일정, 채팅방, 멤버십, 권한 등 모든 데이터가 함께 삭제됩니다.
  - 그룹 권한 설정 시 유효성 검증이 강화되고, 일부 역할에 대한 제한이 명확해졌습니다.
  - 그룹 업데이트 및 삭제 시 리더 검증과 그룹 존재 여부 확인이 일원화되었습니다.

- **버그 수정**
  - 없음

- **기타**
  - API 응답에 표준화된 페이징 응답 포맷이 도입되었습니다.
  - 일부 코드 및 주석이 정리되고, 상수 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->