### PR TITLE
Feat(Post): 공지글 리더 권한 검증 및 게시글/그룹 로직 정리

### DIFF
--- a/src/main/java/team/budderz/buddyspace/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/exception/PostErrorCode.java
@@ -14,7 +14,7 @@ public enum PostErrorCode implements ErrorCode {
     , UNAUTHORIZED_POST_UPDATE(HttpStatus.FORBIDDEN.value(), "P004", "게시글 수정 권한이 없습니다.")
     , UNAUTHORIZED_POST_DELETE(HttpStatus.FORBIDDEN.value(), "P005", "게시글 삭제 권한이 없습니다.")
     , NOTICE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST.value(), "P006", "공지사항은 최대 5개까지만 등록할 수 있습니다.")
-    , NOTICE_POST_ONLY_ALLOWED_BY_LEADER(HttpStatus.BAD_REQUEST.value(), "P007", "공지글은 리더만 설정 가능합니다.")
+    , NOTICE_POST_ONLY_ALLOWED_BY_LEADER(HttpStatus.FORBIDDEN.value(), "P007", "공지글은 리더만 설정 가능합니다.")
     ;
 
 

--- a/src/main/java/team/budderz/buddyspace/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/exception/PostErrorCode.java
@@ -14,6 +14,7 @@ public enum PostErrorCode implements ErrorCode {
     , UNAUTHORIZED_POST_UPDATE(HttpStatus.FORBIDDEN.value(), "P004", "게시글 수정 권한이 없습니다.")
     , UNAUTHORIZED_POST_DELETE(HttpStatus.FORBIDDEN.value(), "P005", "게시글 삭제 권한이 없습니다.")
     , NOTICE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST.value(), "P006", "공지사항은 최대 5개까지만 등록할 수 있습니다.")
+    , NOTICE_POST_ONLY_ALLOWED_BY_LEADER(HttpStatus.BAD_REQUEST.value(), "P007", "공지글은 리더만 설정 가능합니다.")
     ;
 
 

--- a/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
@@ -160,8 +160,7 @@ public class PostService {
             Long groupId,
             Long postId
     ) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BaseException(PostErrorCode.GROUP_ID_NOT_FOUND));
+        Group group = validator.findGroupOrThrow(groupId);
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BaseException(PostErrorCode.POST_ID_NOT_FOUND));

--- a/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
@@ -103,24 +103,19 @@ public class PostService {
 
     // 게시글 삭제
     @Transactional
-    public Void deletePost (
+    public void deletePost (
             Long groupId,
             Long postId,
             Long userId
     ) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BaseException(PostErrorCode.GROUP_ID_NOT_FOUND));
+        Group group = validator.findGroupOrThrow(groupId);
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BaseException(PostErrorCode.POST_ID_NOT_FOUND));
 
-        if (!Objects.equals(post.getUser().getId(), userId)
-                && !Objects.equals(group.getLeader().getId(), userId)) {
-            throw new BaseException(PostErrorCode.UNAUTHORIZED_POST_DELETE);
-        }
+        validator.validatePermission(userId, groupId, PermissionType.DELETE_POST, post.getUser().getId());
 
         postRepository.delete(post);
-        return null;
     }
 
     // 게시글 전체 조회

--- a/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
@@ -6,12 +6,13 @@ import org.springframework.transaction.annotation.Transactional;
 import team.budderz.buddyspace.api.post.request.SavePostRequest;
 import team.budderz.buddyspace.api.post.request.UpdatePostRequest;
 import team.budderz.buddyspace.api.post.response.*;
+import team.budderz.buddyspace.domain.group.validator.GroupValidator;
 import team.budderz.buddyspace.domain.post.exception.PostErrorCode;
 import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.comment.entity.Comment;
 import team.budderz.buddyspace.infra.database.comment.repository.CommentRepository;
 import team.budderz.buddyspace.infra.database.group.entity.Group;
-import team.budderz.buddyspace.infra.database.group.repository.GroupRepository;
+import team.budderz.buddyspace.infra.database.group.entity.PermissionType;
 import team.budderz.buddyspace.infra.database.post.entity.Post;
 import team.budderz.buddyspace.infra.database.post.repository.PostRepository;
 import team.budderz.buddyspace.infra.database.user.entity.User;
@@ -26,9 +27,9 @@ import java.util.stream.Collectors;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private final GroupValidator validator;
 
     // 게시글 저장
     @Transactional
@@ -37,13 +38,18 @@ public class PostService {
             Long userId,
             SavePostRequest request
     ) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BaseException(PostErrorCode.GROUP_ID_NOT_FOUND));
+        Group group = validator.findGroupOrThrow(groupId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(PostErrorCode.USER_ID_NOT_FOUND));
 
+        validator.validatePermission(userId, groupId, PermissionType.CREATE_POST);
+
         if (request.isNotice()) {
+            if (!Objects.equals(userId, group.getLeader().getId())) {
+                throw new BaseException(PostErrorCode.NOTICE_POST_ONLY_ALLOWED_BY_LEADER);
+            }
+
             Long noticeNum = postRepository.countByGroupIdAndIsNoticeTrue(groupId);
 
             if (noticeNum >= 5) {


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #68 
close #68
## 📌 개요
- 공지글 작성 및 수정 시 그룹 리더 권한 검증을 추가
- 게시글 삭제 및 그룹 조회 시 Validator 메서드를 사용해 중복 로직 제거
## 📝 PR 유형
- 공지글 작성 시 리더 여부 검증 기능 추가
- 공지글 수정 시 리더 여부 검증 기능 추가
- 게시글 삭제 시 Validator의 권한 검증 메서드 사용 및 반환 타입을 `void`로 변경
- 그룹 조회 시 Validator의 `findGroupOrThrow` 사용으로 중복 코드 제거

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 공지글 작성 및 수정 시 그룹 리더만 접근 가능하도록 검증했습니다.
- [x] 게시글 삭제 시 권한 검증을 Validator에서 처리하도록 정리했습니다.
- [x] 그룹 조회 시 중복된 로직 없이 Validator를 사용하도록 리팩토링했습니다.

## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 공지글 작성 및 수정 시 그룹 리더만 가능하도록 제한이 추가되었습니다. 리더가 아닌 사용자가 시도할 경우 오류 메시지가 표시됩니다.

- **리팩터링**
  - 그룹 및 권한 검증 로직이 일관적으로 처리되어 권한 확인이 더욱 명확해졌습니다.

- **기타**
  - 게시글 삭제 시 반환 타입이 변경되어 불필요한 반환값이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->