### PR TITLE
Refactor(Comment): 게시글 조회 시 상위 댓글만 반환하도록 로직 수정

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/post/response/FindPostResponse.java
+++ b/src/main/java/team/budderz/buddyspace/api/post/response/FindPostResponse.java
@@ -18,13 +18,17 @@ public record FindPostResponse(
         List<FindsCommentResponse> comments
 ) {
     public static FindPostResponse from(Post post, List<Comment> comments) {
+        List<Comment> topLevelComments = comments.stream()
+                .filter(c -> c.getParent() == null)
+                .collect(Collectors.toList());
+
         return new FindPostResponse(
                 post.getUser().getImageUrl(),
                 post.getUser().getName(),
                 post.getCreatedAt(),
                 post.getContent(),
                 (long) post.getComments().size(),
-                comments.stream()
+                topLevelComments.stream()
                         .map(FindsCommentResponse::from)
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList())


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #124 
close #124
## 📌 개요
- 게시글 상세 조회 시 모든 댓글을 반환하던 기존 로직을 수정하여, 상위 댓글(최상위 부모)만 반환하도록 변경
## 📝 PR 유형
- 댓글 조회 로직 리팩토링
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 게시글 상세 조회 시 상위 댓글만 반환되도록 정상 동작 확인
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->
- 이전에 발생했던 코드 에러는 대부분이 에러였습니다!! 모두 정상작동 하는거 확인 후에 PR 올립니다!

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 게시글 조회 시, 댓글 목록에 이제 최상위 댓글(부모가 없는 댓글)만 표시됩니다. 대댓글(자식 댓글)은 목록에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->