### PR TITLE
feat: 메시지 삭제 기능 구현 #153

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatWebSocketController.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import team.budderz.buddyspace.api.chat.request.ws.ChatMessageSendRequest;
+import team.budderz.buddyspace.api.chat.request.ws.DeleteMessageRequest;
 import team.budderz.buddyspace.api.chat.request.ws.ReadReceiptRequest;
 import team.budderz.buddyspace.api.chat.response.ws.ChatMessageResponse;
 import team.budderz.buddyspace.api.chat.response.ws.ReadReceiptResponse;
@@ -44,7 +45,7 @@ public class ChatWebSocketController {
             ChatMessageResponse savedMessage = chatMessageService.saveChatMessage(completedRequest);
 
             // Broadcast
-            String destination = "/sub/chat/rooms/" + completedRequest.roomId();
+            String destination = "/sub/chat/rooms/" + completedRequest.roomId() + "/messages";
             messagingTemplate.convertAndSend(destination, savedMessage);
 
         } catch (Exception e) {
@@ -88,6 +89,38 @@ public class ChatWebSocketController {
         messagingTemplate.convertAndSend(
                 "/sub/chat/rooms/" + roomId + "/read-sync",
                 allReads
+        );
+    }
+
+    /**
+     * WebSocket 으로 내 메시지 삭제 요청
+     * 클라이언트에서 stompClient.send("/pub/chat/rooms/{roomId}/delete", …)
+     */
+    @MessageMapping("/chat/rooms/{roomId}/delete")
+    @Transactional
+    public void deleteMessageWs(
+            @DestinationVariable Long roomId,
+            DeleteMessageRequest payload,
+            MessageHeaders headers
+    ) {
+        Long userId    = extractSenderId(headers);
+        Long messageId = payload.messageId();
+
+        // WS 전용 삭제
+        chatMessageService.deleteMessageByRoom(roomId, messageId, userId);
+
+        // 삭제 이벤트 브로드캐스트 (클라이언트가 이걸 받아서 li 제거)
+        Map<String,Object> event = Map.of(
+                "event","message:delete",
+                "data", Map.of(
+                        "roomId",    roomId,
+                        "messageId", messageId,
+                        "senderId",  userId
+                )
+        );
+        messagingTemplate.convertAndSend(
+                "/sub/chat/rooms/" + roomId + "/messages",
+                event
         );
     }
 

--- a/src/main/java/team/budderz/buddyspace/api/chat/request/ws/DeleteMessageRequest.java
+++ b/src/main/java/team/budderz/buddyspace/api/chat/request/ws/DeleteMessageRequest.java
@@ -1,0 +1,3 @@
+package team.budderz.buddyspace.api.chat.request.ws;
+
+public record DeleteMessageRequest(Long messageId) {}

--- a/src/main/java/team/budderz/buddyspace/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/team/budderz/buddyspace/domain/chat/exception/ChatErrorCode.java
@@ -22,7 +22,8 @@ public enum ChatErrorCode implements ErrorCode {
     MESSAGE_NOT_IN_ROOM(404, "C009", "메시지가 해당 채팅방에 속하지 않습니다."),
     NO_PERMISSION           (403, "C010", "권한이 없습니다."),
     USER_ALREADY_IN_CHAT_ROOM(409, "C011", "이미 채팅방에 참여중인 사용자입니다."),
-    CANNOT_KICK_SELF(400, "C012", "본인은 강퇴할 수 없습니다.");
+    CANNOT_KICK_SELF(400, "C012", "본인은 강퇴할 수 없습니다."),
+    MESSAGE_DELETE_TIME_EXPIRED(400, "C013", "메시지 삭제 가능 시간이 지났습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/resources/static/test-websocket.html
+++ b/src/main/resources/static/test-websocket.html
@@ -92,10 +92,6 @@
     function onMessage(m) {
         const dto = JSON.parse(m.body);
         showMessage(dto, myId, false);
-        // 내가 보낸 메시지가 아니면 읽음 보고
-        if (Number(dto.senderId) !== Number(myId)) {
-            sendRead(dto.messageId);
-        }
     }
 
     /* ───────── 연결 ───────── */
@@ -108,36 +104,65 @@
         if (!token || !groupId || !roomId) return alert('필수 정보가 없습니다.');
         if (stompClient?.connected) return;
 
+        // 1) SockJS + STOMP client 생성
         const socket = new SockJS(`http://localhost:8080/ws?access_token=${token}`);
         stompClient = Stomp.over(socket);
 
-        stompClient.connect({ Authorization: rawToken }, () => {
-            document.getElementById('messages').innerHTML = '';
-            latestSeen = 0;
-            messageMap.clear();
+        // 2) STOMP 연결 (성공 콜백, 에러 콜백 모두 전달)
+        stompClient.connect(
+            { Authorization: rawToken },
+            frame => {
+                // --- 연결 성공했을 때 실행될 로직 ---
+                document.getElementById('messages').innerHTML = '';
+                latestSeen = 0;
+                messageMap.clear();
 
-            // 1) 멤버 정보 fetch → 구독
-            fetchMembers(roomId, token).then(members => {
-                memberIds = members.map(m => m.userId);
-                participantCount = memberIds.length;
-                subscribeMemberUpdates(roomId);
+                // (1) 멤버 fetch & 구독
+                fetchMembers(roomId, token).then(members => {
+                    memberIds       = members.map(m => m.userId);
+                    participantCount = memberIds.length;
+                    subscribeMemberUpdates(roomId);
 
-                // 2) 과거 메시지 불러오기 → 끝나면 onHistoryLoaded 에서 sync, 그 뒤에 실시간 구독
-                fetchChatHistory(token, groupId, roomId, myId)
-                    .then(() => {
-                        // 3) 메시지/읽음 실시간 구독
-                        subscribeRealtime(roomId);
-                    });
-            });
-        }, console.error);
+                    // (2) 과거 메시지 로드
+                    fetchChatHistory(token, groupId, roomId, myId)
+                        .then(() => {
+                            // (3) 실시간 메시지+읽음 구독
+                            subscribeRealtime(roomId);
+                        });
+                });
+            },
+            errorFrame => {
+                // --- 서버에서 에러 frame 이 내려왔을 때 실행 ---
+                let errMsg = '알 수 없는 오류가 발생했습니다.';
+                try {
+                    const body = JSON.parse(errorFrame.body);
+                    errMsg = body.error || JSON.stringify(body);
+                } catch (_){ /* 파싱 실패해도 그냥 메시지 객체 사용 */ }
+                alert(`삭제 실패: ${errMsg}`);
+            }
+        );
+
+        stompClient.subscribe('/user/queue/errors', m => {
+            alert(m.body);
+        });
     }
 
     function subscribeRealtime(roomId) {
-        // 메시지
+        // 메시지 수신 + 삭제
         currentSub?.unsubscribe();
         currentSub = stompClient.subscribe(
-            `/sub/chat/rooms/${roomId}`,
-            onMessage
+            `/sub/chat/rooms/${roomId}/messages`,
+            frame => {
+                const payload = JSON.parse(frame.body);
+
+                if (payload.event === 'message:delete') {
+                    // 삭제 이벤트
+                    document.querySelector(`li[data-id='${payload.data.messageId}']`)?.remove();
+                } else {
+                    // 신규 메시지
+                    showMessage(payload, myId, false);
+                }
+            }
         );
 
         // 단건 읽음 Ack
@@ -220,6 +245,17 @@
         });
     }
 
+    function disconnect() {
+        if (stompClient) {
+            stompClient.disconnect(() => console.log("WebSocket disconnected"));
+            document.getElementById('messages').innerHTML = '';
+            stompClient = null;
+        }
+        currentSub?.unsubscribe();
+        readSub?.unsubscribe();
+        readSyncSub?.unsubscribe();
+    }
+
     /* ───────── 메시지 전송 ───────── */
     function sendMessage() {
         const content = document.getElementById('message').value.trim();
@@ -254,6 +290,15 @@
 
         li.append(bubble, meta);
 
+        if (mine) {
+            const btn = document.createElement('button');
+            btn.textContent = '삭제';
+            btn.style.marginLeft = '8px';
+            btn.onclick = () => deleteMessage(msgId);
+            li.append(btn);
+        }
+
+
         ul.appendChild(li);
         if (!isHistory) ul.scrollTop = ul.scrollHeight;
 
@@ -264,10 +309,23 @@
         });
 
         if (msgId > latestSeen) latestSeen = msgId;
+    }
 
-        if (!isHistory && Number(msg.senderId) !== Number(myId)) {
-            sendRead(msg.messageId);
+    function deleteMessage(messageId) {
+        // 클릭 즉시 내 화면에서 해당 <li> 삭제
+        const li = document.querySelector(`li[data-id='${messageId}']`);
+        if (li) {
+            li.remove();
+            messageMap.delete(messageId);
         }
+
+        // WebSocket 으로 서버에 삭제 요청
+        const roomId = localStorage.getItem('roomId');
+        stompClient.send(
+            `/pub/chat/rooms/${roomId}/delete`,
+            {},                                 // 헤더 (인증은 이미 WS 연결 시 핸드쉐이크 단계에서 처리됨)
+            JSON.stringify({ messageId })
+        );
     }
 
     /* ───── 읽음 뱃지 helper ───── */


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #153
close #153
## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- 사용자가 자신이 보낸 메시지를 삭제할 수 있는 WebSocket 핸들러를 구현했습니다.  
- 보낸 지 5분 이내의 메시지에 대해서만 삭제가 가능하며, 그 이후에는 삭제 시도 시 에러를 반환하도록 했습니다.

## 📝 PR 유형
어떤 변경 사항이 있나요?
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->
- `ChatMessageService.deleteMessage` 와 `ChatWebSocketController.deleteMessageWs` 에서 동일한 삭제 로직을 재활용하도록 설계했습니다.  
<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 채팅 메시지 삭제 기능이 추가되었습니다. 사용자는 자신이 보낸 메시지를 5분 이내에 삭제할 수 있습니다.
    - 메시지 삭제 시 실시간으로 UI에서 해당 메시지가 제거되고, 모든 참여자에게 삭제 이벤트가 전송됩니다.

- **버그 수정 및 개선**
    - 실시간 메시지 구독 경로가 일관성 있게 변경되었습니다.
    - 웹소켓 연결 및 오류 처리 방식이 개선되었습니다.
    - 연결 해제 및 메시지 목록 초기화 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->