### PR TITLE
Feat(Notification): 알림 URL 생성 및 실시간 알림 전송 기능 구현

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/notification/response/NotificationArgs.java
+++ b/src/main/java/team/budderz/buddyspace/api/notification/response/NotificationArgs.java
@@ -4,6 +4,9 @@ public record NotificationArgs(
         String senderName,
         String groupName,
         String content,
-        Long targetId
+        Long memberId,
+        Long groupId,
+        Long postId,
+        Long commentId
 ) {
 }

--- a/src/main/java/team/budderz/buddyspace/domain/comment/event/CommentEvent.java
+++ b/src/main/java/team/budderz/buddyspace/domain/comment/event/CommentEvent.java
@@ -1,0 +1,17 @@
+package team.budderz.buddyspace.domain.comment.event;
+
+import lombok.Getter;
+import team.budderz.buddyspace.infra.database.comment.entity.Comment;
+import team.budderz.buddyspace.infra.database.user.entity.User;
+
+@Getter
+public class CommentEvent {
+    private final Comment comment;
+    private final User writer;
+
+    public CommentEvent(Comment comment, User writer) {
+        this.comment = comment;
+        this.writer = writer;
+    }
+}
+

--- a/src/main/java/team/budderz/buddyspace/domain/comment/event/CommentEventHandler.java
+++ b/src/main/java/team/budderz/buddyspace/domain/comment/event/CommentEventHandler.java
@@ -1,0 +1,106 @@
+package team.budderz.buddyspace.domain.comment.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.service.NotificationService;
+import team.budderz.buddyspace.domain.post.event.PostEvent;
+import team.budderz.buddyspace.infra.database.comment.entity.Comment;
+import team.budderz.buddyspace.infra.database.membership.entity.JoinStatus;
+import team.budderz.buddyspace.infra.database.membership.entity.Membership;
+import team.budderz.buddyspace.infra.database.membership.repository.MembershipRepository;
+import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
+import team.budderz.buddyspace.infra.database.post.entity.Post;
+import team.budderz.buddyspace.infra.database.user.entity.User;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CommentEventHandler {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleComment(CommentEvent event) {
+        Comment comment = event.getComment();
+        User writer = event.getWriter();
+        Post post = comment.getPost();
+        User postWriter = post.getUser();
+
+        if (!postWriter.getId().equals(writer.getId())) {
+            NotificationArgs args = new NotificationArgs(
+                    writer.getName(),
+                    post.getGroup().getName(),
+                    null,
+                    postWriter.getId(),
+                    post.getGroup().getId(),
+                    post.getId(),
+                    comment.getId()
+            );
+
+            notificationService.sendNotice(
+                    NotificationType.COMMENT,
+                    postWriter,
+                    post.getGroup(),
+                    args
+            );
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReply(ReplyEvent event) {
+        Comment reply = event.getRecomment();
+        User writer = event.getWriter();
+        Post post = reply.getPost();
+        User postWriter = post.getUser();
+        User parentWriter = reply.getParent().getUser();
+
+        // 게시글 작성자에게
+        if (!postWriter.getId().equals(writer.getId())) {
+            NotificationArgs args = new NotificationArgs(
+                    writer.getName(),
+                    post.getGroup().getName(),
+                    null,
+                    postWriter.getId(),
+                    post.getGroup().getId(),
+                    post.getId(),
+                    reply.getId()
+            );
+
+            notificationService.sendNotice(
+                    NotificationType.REPLY,
+                    postWriter,
+                    post.getGroup(),
+                    args
+            );
+        }
+
+        // 부모 댓글 작성자에게 (작성자, 게시글 작성자 제외)
+        if (!parentWriter.getId().equals(writer.getId())
+                && !parentWriter.getId().equals(postWriter.getId())) {
+            NotificationArgs args = new NotificationArgs(
+                    writer.getName(),
+                    post.getGroup().getName(),
+                    null,
+                    parentWriter.getId(),
+                    post.getGroup().getId(),
+                    post.getId(),
+                    reply.getId()
+            );
+
+            notificationService.sendNotice(
+                    NotificationType.REPLY,
+                    parentWriter,
+                    post.getGroup(),
+                    args
+            );
+        }
+    }
+
+}

--- a/src/main/java/team/budderz/buddyspace/domain/comment/event/ReplyEvent.java
+++ b/src/main/java/team/budderz/buddyspace/domain/comment/event/ReplyEvent.java
@@ -1,0 +1,17 @@
+package team.budderz.buddyspace.domain.comment.event;
+
+import lombok.Getter;
+import team.budderz.buddyspace.infra.database.comment.entity.Comment;
+import team.budderz.buddyspace.infra.database.user.entity.User;
+
+@Getter
+public class ReplyEvent {
+    private final Comment recomment;
+    private final User writer;
+
+    public ReplyEvent(Comment recomment, User writer) {
+        this.recomment = recomment;
+        this.writer = writer;
+    }
+}
+

--- a/src/main/java/team/budderz/buddyspace/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/exception/NotificationErrorCode.java
@@ -12,7 +12,7 @@ public enum NotificationErrorCode implements ErrorCode {
     , USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "N002", "존재하지 않는 유저입니다.")
     , NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "N003", "존재하지 않는 알람입니다.")
     , NO_AUTH_TO_READ_NOTIFICATION(HttpStatus.FORBIDDEN.value(), "N004", "해당 알림을 조회할 권한이 없습니다.")
-
+    , INVALID_NOTIFICATION_ARGUMENT( HttpStatus.BAD_REQUEST.value(), "N005", "알림 URL 생성에 필요한 인자가 없습니다.");
     ;
 
 

--- a/src/main/java/team/budderz/buddyspace/domain/notification/service/NotificationService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/service/NotificationService.java
@@ -29,6 +29,7 @@ public class NotificationService {
     private final SsePushService ssePushService;
 
     // 알림 보내기
+    @Transactional
     public void sendNotice(
             NotificationType type,
             User receiver,

--- a/src/main/java/team/budderz/buddyspace/domain/notification/service/NotificationService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/service/NotificationService.java
@@ -1,15 +1,20 @@
 package team.budderz.buddyspace.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
+import org.redisson.client.protocol.decoder.StreamGroupInfoDecoder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.budderz.buddyspace.api.notification.response.FindsNotificationResponse;
+import team.budderz.buddyspace.api.notification.response.NotificationArgs;
 import team.budderz.buddyspace.api.notification.response.NotificationResponse;
 import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
 import team.budderz.buddyspace.global.exception.BaseException;
+import team.budderz.buddyspace.global.sse.service.SsePushService;
+import team.budderz.buddyspace.infra.database.group.entity.Group;
 import team.budderz.buddyspace.infra.database.notification.entity.Notification;
+import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 import team.budderz.buddyspace.infra.database.notification.repository.NotificationRepository;
 import team.budderz.buddyspace.infra.database.user.entity.User;
 import team.budderz.buddyspace.infra.database.user.repository.UserRepository;
@@ -21,8 +26,31 @@ public class NotificationService {
     private final NotificationTemplateService templateService;
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final SsePushService ssePushService;
 
     // 알림 보내기
+    public void sendNotice(
+            NotificationType type,
+            User receiver,
+            Group group,
+            NotificationArgs args
+    ) {
+        String content = templateService.generateContent(type, args);
+        String url = templateService.generateUrl(type, args);
+
+        Notification notification = Notification.builder()
+                .user(receiver)
+                .group(group)
+                .type(type)
+                .content(content)
+                .url(url)
+                .isRead(false)
+                .build();
+
+        notificationRepository.save(notification);
+
+        ssePushService.send(receiver.getId(), notification);
+    }
 
     // 알림 모음
     @Transactional(readOnly = true)

--- a/src/main/java/team/budderz/buddyspace/domain/notification/service/NotificationTemplateService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/service/NotificationTemplateService.java
@@ -29,4 +29,13 @@ public class NotificationTemplateService {
 
         return template.generateContent(args);
     }
+
+    public String generateUrl(NotificationType type, NotificationArgs args) {
+        NotificationTemplate template = templateMap.get(type);
+        if(template == null) {
+            throw new BaseException(NotificationErrorCode.UNSUPPORTED_NOTIFICATION_TYPE);
+        }
+
+        return template.generateUrl(args);
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/CommentNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/CommentNotificationTemplate.java
@@ -15,4 +15,9 @@ public class CommentNotificationTemplate implements NotificationTemplate{
     public String generateContent(NotificationArgs args) {
         return String.format("%s 님이 내 게시글에 댓글을 남겼습니다.", args.senderName());
     }
+
+    @Override
+    public String generateUrl(NotificationArgs args) {
+        return "/api/group/" + args.groupId() + "/posts/" + args.postId() + "/comments/" + args.commentId();
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/CommentNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/CommentNotificationTemplate.java
@@ -2,6 +2,8 @@ package team.budderz.buddyspace.domain.notification.template;
 
 import org.springframework.stereotype.Component;
 import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
+import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 
 @Component
@@ -18,6 +20,9 @@ public class CommentNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/group/" + args.groupId() + "/posts/" + args.postId() + "/comments/" + args.commentId();
+        if (args == null || args.groupId() == null || args.postId() == null || args.commentId() == null) {
+            throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
+        }
+        return String.format("/api/groups/%d/posts/%d/comments/%d", args.groupId(), args.postId(), args.commentId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
@@ -15,4 +15,9 @@ public class JoinApprovedNotificationTemplate implements NotificationTemplate{
     public String generateContent(NotificationArgs args) {
         return "관리자가 가입 요청을 수락했습니다.";
     }
+
+    @Override
+    public String generateUrl(NotificationArgs args) {
+        return "/api/group/" + args.groupId();
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
@@ -2,6 +2,8 @@ package team.budderz.buddyspace.domain.notification.template;
 
 import org.springframework.stereotype.Component;
 import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
+import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 
 @Component
@@ -18,6 +20,9 @@ public class JoinApprovedNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/group/" + args.groupId();
+        if (args == null || args.groupId() == null) {
+            throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
+        }
+        return String.format("/api/groups/%d", args.groupId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
@@ -18,6 +18,6 @@ public class JoinRequestNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/group/" + args.groupId();
+        return "/api/groups/" + args.groupId() + "/members/" + args.memberId() + "/approve";
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
@@ -15,4 +15,9 @@ public class JoinRequestNotificationTemplate implements NotificationTemplate{
     public String generateContent(NotificationArgs args) {
         return String.format("%s 님이 가입 요청을 보냈습니다.", args.senderName());
     }
+
+    @Override
+    public String generateUrl(NotificationArgs args) {
+        return "/api/group/" + args.groupId();
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
@@ -2,6 +2,8 @@ package team.budderz.buddyspace.domain.notification.template;
 
 import org.springframework.stereotype.Component;
 import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
+import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 
 @Component
@@ -18,6 +20,9 @@ public class JoinRequestNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/groups/" + args.groupId() + "/members/" + args.memberId() + "/approve";
+        if (args == null || args.groupId() == null || args.postId() == null || args.memberId() == null) {
+            throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
+        }
+        return String.format("/api/groups/%d/members/%d/approve", args.groupId(), args.memberId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/NoticeNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/NoticeNotificationTemplate.java
@@ -2,6 +2,8 @@ package team.budderz.buddyspace.domain.notification.template;
 
 import org.springframework.stereotype.Component;
 import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
+import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 
 @Component
@@ -18,6 +20,9 @@ public class NoticeNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/group/" + args.groupId() + "/posts/" + args.postId();
+        if (args == null || args.groupId() == null || args.postId() == null) {
+            throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
+        }
+        return String.format("/api/groups/%d/posts/%d", args.groupId(), args.postId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/NoticeNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/NoticeNotificationTemplate.java
@@ -15,4 +15,9 @@ public class NoticeNotificationTemplate implements NotificationTemplate{
     public String generateContent(NotificationArgs args) {
         return String.format("[%s] 그룹에 새 공지가 등록되었습니다.", args.groupName());
     }
+
+    @Override
+    public String generateUrl(NotificationArgs args) {
+        return "/api/group/" + args.groupId() + "/posts/" + args.postId();
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/NotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/NotificationTemplate.java
@@ -6,4 +6,5 @@ import team.budderz.buddyspace.infra.database.notification.entity.NotificationTy
 public interface NotificationTemplate {
     NotificationType getType();
     String generateContent(NotificationArgs args);
+    String generateUrl(NotificationArgs args);
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/PostNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/PostNotificationTemplate.java
@@ -15,4 +15,9 @@ public class PostNotificationTemplate implements NotificationTemplate{
     public String generateContent(NotificationArgs args) {
         return String.format("%s 님이 새 게시글을 올렸습니다.", args.senderName());
     }
+
+    @Override
+    public String generateUrl(NotificationArgs args) {
+        return "/api/group/" + args.groupId() + "/posts/" + args.postId();
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/PostNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/PostNotificationTemplate.java
@@ -2,6 +2,8 @@ package team.budderz.buddyspace.domain.notification.template;
 
 import org.springframework.stereotype.Component;
 import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
+import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 
 @Component
@@ -18,6 +20,9 @@ public class PostNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/group/" + args.groupId() + "/posts/" + args.postId();
+        if (args == null || args.groupId() == null || args.postId() == null) {
+            throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
+        }
+        return String.format("/api/groups/%d/posts/%d", args.groupId(), args.postId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/ReplyNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/ReplyNotificationTemplate.java
@@ -15,4 +15,9 @@ public class ReplyNotificationTemplate implements NotificationTemplate{
     public String generateContent(NotificationArgs args) {
         return String.format("%s 님이 내 댓글에 댓글을 남겼습니다.", args.senderName());
     }
+
+    @Override
+    public String generateUrl(NotificationArgs args) {
+        return "/api/group/" + args.groupId() + "/posts/" + args.postId() + "/comments/" + args.commentId();
+    }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/ReplyNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/ReplyNotificationTemplate.java
@@ -2,6 +2,8 @@ package team.budderz.buddyspace.domain.notification.template;
 
 import org.springframework.stereotype.Component;
 import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.exception.NotificationErrorCode;
+import team.budderz.buddyspace.global.exception.BaseException;
 import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
 
 @Component
@@ -18,6 +20,9 @@ public class ReplyNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        return "/api/group/" + args.groupId() + "/posts/" + args.postId() + "/comments/" + args.commentId();
+        if (args == null || args.groupId() == null || args.postId() == null || args.commentId() == null) {
+            throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
+        }
+        return String.format("/api/groups/%d/posts/%d/comments/%d", args.groupId(), args.postId(), args.commentId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/post/event/PostEvent.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/event/PostEvent.java
@@ -1,0 +1,16 @@
+package team.budderz.buddyspace.domain.post.event;
+
+import lombok.Getter;
+import team.budderz.buddyspace.infra.database.post.entity.Post;
+import team.budderz.buddyspace.infra.database.user.entity.User;
+
+@Getter
+public class PostEvent {
+    private final Post post;
+    private final User writer;
+
+    public PostEvent(Post post, User writer) {
+        this.post = post;
+        this.writer = writer;
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/domain/post/event/PostEventHandler.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/event/PostEventHandler.java
@@ -26,8 +26,15 @@ public class PostEventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PostEvent event) {
+        if (event == null || event.getPost() == null || event.getWriter() == null) {
+            return;
+        }
         Post post = event.getPost();
         User user = event.getWriter();
+
+        if (post.getGroup() == null) {
+            return;
+        }
         Long groupId = post.getGroup().getId();
 
         List<Membership> members = membershipRepository.findByGroup_IdAndJoinStatus(groupId, JoinStatus.APPROVED);

--- a/src/main/java/team/budderz/buddyspace/domain/post/event/PostEventHandler.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/event/PostEventHandler.java
@@ -1,0 +1,62 @@
+package team.budderz.buddyspace.domain.post.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.budderz.buddyspace.api.notification.response.NotificationArgs;
+import team.budderz.buddyspace.domain.notification.service.NotificationService;
+import team.budderz.buddyspace.infra.database.membership.entity.JoinStatus;
+import team.budderz.buddyspace.infra.database.membership.entity.Membership;
+import team.budderz.buddyspace.infra.database.membership.repository.MembershipRepository;
+import team.budderz.buddyspace.infra.database.notification.entity.NotificationType;
+import team.budderz.buddyspace.infra.database.post.entity.Post;
+import team.budderz.buddyspace.infra.database.user.entity.User;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PostEventHandler {
+
+    private final NotificationService notificationService;
+    private final MembershipRepository membershipRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PostEvent event) {
+        Post post = event.getPost();
+        User user = event.getWriter();
+        Long groupId = post.getGroup().getId();
+
+        List<Membership> members = membershipRepository.findByGroup_IdAndJoinStatus(groupId, JoinStatus.APPROVED);
+
+        for (Membership membership : members) {
+            User member = membership.getUser();
+
+            if (member.getId().equals(user.getId())) continue;
+
+            NotificationType type = post.getIsNotice() ?
+                    NotificationType.NOTICE :
+                    NotificationType.POST;
+
+            NotificationArgs baseArgs = new NotificationArgs(
+                    user.getName(),
+                    post.getGroup().getName(),
+                    null,
+                    member.getId(),
+                    groupId,
+                    post.getId(),
+                    null
+            );
+
+            notificationService.sendNotice(
+                    type,
+                    member,
+                    post.getGroup(),
+                    baseArgs
+            );
+        }
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/global/sse/controller/NotificationSseController.java
+++ b/src/main/java/team/budderz/buddyspace/global/sse/controller/NotificationSseController.java
@@ -1,0 +1,49 @@
+package team.budderz.buddyspace.global.sse.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.budderz.buddyspace.global.security.UserAuth;
+import team.budderz.buddyspace.global.sse.repository.EmitterRepository;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationSseController {
+
+    private final EmitterRepository emitterRepository;
+    private static final Long TIMEOUT = 60 * 60 * 1000L; // 1시간 유지
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal UserAuth userAuth
+            ) {
+        Long userId = userAuth.getUserId();
+
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitterRepository.save(userId, emitter);
+
+        // 연결 테스트용 초기 데이터 전송
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("SSE 연결 완료")
+            );
+        } catch (IOException e) {
+            emitterRepository.remove(userId);
+        }
+
+        // 연결 종료 시 정리
+        emitter.onCompletion(() -> emitterRepository.remove(userId));
+        emitter.onTimeout(() -> emitterRepository.remove(userId));
+        emitter.onError((e) -> emitterRepository.remove(userId));
+
+        return emitter;
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/global/sse/repository/EmitterRepository.java
+++ b/src/main/java/team/budderz/buddyspace/global/sse/repository/EmitterRepository.java
@@ -1,0 +1,25 @@
+package team.budderz.buddyspace.global.sse.repository;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class EmitterRepository {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(Long userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
+    }
+
+    public Optional<SseEmitter> get(Long userId) {
+        return Optional.ofNullable(emitters.get(userId));
+    }
+
+    public void remove(Long userId) {
+        emitters.remove(userId);
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/global/sse/repository/EmitterRepository.java
+++ b/src/main/java/team/budderz/buddyspace/global/sse/repository/EmitterRepository.java
@@ -17,9 +17,18 @@ public class EmitterRepository {
         remove(userId); // 기존 emitter이 있다면 정리
 
         // emitter 생명주기 콜백 등록
-        emitter.onCompletion(() -> remove(userId));
-        emitter.onTimeout(() -> remove(userId));
-        emitter.onError((ex) -> remove(userId));
+        emitter.onCompletion(() -> {
+            log.debug("SSE 연결 완료: userId={}", userId);
+            emitters.remove(userId);
+        });
+        emitter.onTimeout(() -> {
+            log.debug("SSE 연결 타임아웃: userId={}", userId);
+            emitters.remove(userId);
+        });
+        emitter.onError((ex) -> {
+            log.debug("SSE 연결 오류: userId={}", userId);
+            emitters.remove(userId);
+        });
 
         emitters.put(userId, emitter);
     }

--- a/src/main/java/team/budderz/buddyspace/global/sse/service/SsePushService.java
+++ b/src/main/java/team/budderz/buddyspace/global/sse/service/SsePushService.java
@@ -1,0 +1,30 @@
+package team.budderz.buddyspace.global.sse.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.budderz.buddyspace.api.notification.response.NotificationResponse;
+import team.budderz.buddyspace.global.sse.repository.EmitterRepository;
+import team.budderz.buddyspace.infra.database.notification.entity.Notification;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class SsePushService {
+
+    private final EmitterRepository emitterRepository;
+
+    public void send(Long userId, Notification notification) {
+        emitterRepository.get(userId).ifPresent(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(NotificationResponse.from(notification))
+                );
+            } catch (IOException e) {
+                emitterRepository.remove(userId);
+            }
+        });
+    }
+}


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #149
close #149
## 📌 개요
- NotificationTemplate 인터페이스에 `generateUrl` 메서드 추가 및 구현
- NotificationArgs DTO 필드 확장 (memberId, groupId, postId, commentId 추가)
- 그룹 승인 알림 관련 URL 생성 로직 구현
- 댓글/대댓글 작성 시 게시글 작성자 또는 댓글 작성자에게 알림 전송 기능 구현
- 게시글 저장 시 그룹 멤버에게 알림 전송 기능 추가
- 알림 전송 서비스 로직 구현 및 SSE(Server-Sent Events) 기반 실시간 알림 기능 구축
## 📝 PR 유형
- NotificationTemplate 인터페이스 및 구현체 변경
- NotificationArgs DTO 필드 확장
- 알림 URL 생성 로직 구현 (특히 그룹 승인 관련)
- 댓글, 대댓글 작성시 알림 전송 기능 추가
- 게시글 저장 시 알림 전송 기능 추가
- SSE 기반 실시간 알림 기능 구현
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] POSTMAN을 통한 API 테스트는 아직 진행 중입니다.
- [ ] 알림 URL 생성 로직 정상 작동 확인
- [ ] 댓글, 게시글 관련 알림 전송 기능 동작 확인
- [ ] SSE 연결 및 실시간 알림 전송 기능 정상 동작
## 🗨️ 팀원에게 전할 말
- 실시간 알림은 SSE를 이용해 구현했으며, 클라이언트와 연결 테스트가 필요합니다.
- POSTMAN 테스트는 아직 진행되지 않아, 실제 서비스 연동 시 추가 확인이 필요합니다.
- URL 생성 로직은 NotificationTemplate에서 처리되니 참고 바랍니다.


<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 실시간 알림을 위한 SSE(Server-Sent Events) 구독 및 푸시 기능이 추가되었습니다. 이제 알림이 발생하면 즉시 브라우저로 전달됩니다.
    - 댓글 및 답글 작성 시 관련 사용자에게 알림이 자동 전송됩니다.
    - 그룹 내 새 게시글 작성 시 구성원들에게 알림이 발송됩니다.
- **알림 개선**
    - 알림에 포함되는 URL이 세분화되어, 클릭 시 관련 게시글, 댓글, 그룹 등으로 바로 이동할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->