### PR TITLE
feat: 채팅방 나가기 기능 구현 #156

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatParticipantRestController.java
+++ b/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatParticipantRestController.java
@@ -1,0 +1,52 @@
+package team.budderz.buddyspace.api.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team.budderz.buddyspace.api.chat.request.rest.AddParticipantRequest;
+import team.budderz.buddyspace.domain.chat.service.ChatRoomServiceFacade;
+import team.budderz.buddyspace.global.security.UserAuth;
+
+@RestController
+@RequestMapping("/api/group/{groupId}/chat/rooms/{roomId}/participants")
+@RequiredArgsConstructor
+public class ChatParticipantRestController {
+
+    private final ChatRoomServiceFacade chatRoomService;
+
+    /** 참여자 초대 */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void addParticipant(
+            @AuthenticationPrincipal UserAuth userAuth,
+            @PathVariable Long groupId,
+            @PathVariable Long roomId,
+            @RequestBody AddParticipantRequest req
+    ) {
+        chatRoomService.addParticipant(groupId, roomId, userAuth.getUserId(), req);
+    }
+
+    /** 참여자 강퇴 */
+    @DeleteMapping("/{targetUserId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void kickParticipant(
+            @AuthenticationPrincipal UserAuth userAuth,
+            @PathVariable Long groupId,
+            @PathVariable Long roomId,
+            @PathVariable Long targetUserId
+    ) {
+        chatRoomService.removeParticipant(groupId, roomId, userAuth.getUserId(), targetUserId);
+    }
+
+    /** 본인 채팅방 나가기 */
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveRoom(
+            @AuthenticationPrincipal UserAuth userAuth,
+            @PathVariable Long groupId,
+            @PathVariable Long roomId
+    ) {
+        chatRoomService.leaveChatRoom(groupId, roomId, userAuth.getUserId());
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatRoomController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import team.budderz.buddyspace.api.chat.request.rest.AddParticipantRequest;
 import team.budderz.buddyspace.api.chat.request.rest.CreateChatRoomRequest;
 import team.budderz.buddyspace.api.chat.request.rest.UpdateChatRoomRequest;
 import team.budderz.buddyspace.api.chat.response.rest.*;
@@ -111,30 +110,6 @@ public class ChatRoomController {
         // (서비스에서 validateMember 등 체크)
         List<ChatRoomMemberResponse> members = chatRoomService.getChatRoomMembers(groupId, roomId, userId);
         return new BaseResponse<>(members);
-    }
-
-    // 참여자 초대  -----------------------------------------------------------------------------------------------------
-    @PostMapping("/{roomId}/participants")
-    @ResponseStatus(HttpStatus.CREATED)
-    public void addParticipant(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long roomId,
-            @RequestBody AddParticipantRequest req
-    ) {
-        chatRoomService.addParticipant(groupId, roomId, userAuth.getUserId(), req);
-    }
-
-    // 참여자 강퇴  -----------------------------------------------------------------------------------------------------
-    @DeleteMapping("/{roomId}/participants/{targetUserId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeParticipant(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long roomId,
-            @PathVariable Long targetUserId
-    ) {
-        chatRoomService.removeParticipant(groupId, roomId, userAuth.getUserId(), targetUserId);
     }
 
     // 읽음 상태 조회 -----------------------------------------------------------------------------------------------------

--- a/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/team/budderz/buddyspace/api/chat/controller/ChatWebSocketController.java
@@ -106,7 +106,9 @@ public class ChatWebSocketController {
         Long userId    = extractSenderId(headers);
         Long messageId = payload.messageId();
 
-        // WS 전용 삭제
+        try {
+
+            // WS 전용 삭제
         chatMessageService.deleteMessageByRoom(roomId, messageId, userId);
 
         // 삭제 이벤트 브로드캐스트 (클라이언트가 이걸 받아서 li 제거)
@@ -122,6 +124,9 @@ public class ChatWebSocketController {
                 "/sub/chat/rooms/" + roomId + "/messages",
                 event
         );
+        } catch (Exception e) {
+            sendErrorToClient("메시지 삭제에 실패했습니다: " + e.getMessage(), userId);
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/src/main/java/team/budderz/buddyspace/domain/chat/service/ChatRoomServiceFacade.java
+++ b/src/main/java/team/budderz/buddyspace/domain/chat/service/ChatRoomServiceFacade.java
@@ -76,7 +76,7 @@ public class ChatRoomServiceFacade {
         chatRoomCommandService.addParticipant(groupId, roomId, userId, req);
     }
 
-    /** 참여자 제거 */
+    /** 참여자 제거(강퇴) */
     @Transactional
     public void removeParticipant(
             Long groupId,
@@ -85,6 +85,16 @@ public class ChatRoomServiceFacade {
             Long targetUserId
     ) {
         chatRoomCommandService.removeParticipant(groupId, roomId, userId, targetUserId);
+    }
+
+    /** 본인 채팅방 나가기 */
+    @Transactional
+    public void leaveChatRoom(
+            Long groupId,
+            Long roomId,
+            Long userId
+    ) {
+        chatRoomCommandService.leaveChatRoom(groupId, roomId, userId);
     }
 
     /** 읽음 상태 조회 */

--- a/src/main/java/team/budderz/buddyspace/infra/database/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/team/budderz/buddyspace/infra/database/chat/repository/ChatParticipantRepository.java
@@ -77,4 +77,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             @Param("lastRead") Long lastReadMessageId
     );
 
+
+
 }

--- a/src/main/resources/static/test-websocket.html
+++ b/src/main/resources/static/test-websocket.html
@@ -35,6 +35,7 @@
     <div class="chat-controls">
         <button onclick="connect()">Connect</button>
         <button onclick="disconnect()">Disconnect</button>
+        <button onclick="leaveRoom()">Leave Room</button>
     </div>
 
     <div class="chat-controls">
@@ -180,6 +181,36 @@
         );
     }
 
+    // 채팅방 나가기
+    function leaveRoom() {
+        const groupId = localStorage.getItem('groupId');
+        const roomId  = localStorage.getItem('roomId');
+        const token   = localStorage.getItem('accessToken');
+
+        fetch(
+            `http://localhost:8080/api/group/${groupId}/chat/rooms/${roomId}/participants/me`,
+            {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': token
+                }
+            }
+        )
+            .then(res => {
+                if (res.status === 204) {
+                    // WS 연결 끊기
+                    disconnect();
+                    // 화면에서 방 나간 뒤 처리 (예: 다른 화면으로 이동)
+                    alert('채팅방을 나갔습니다.');
+                } else {
+                    return res.json().then(body => Promise.reject(body));
+                }
+            })
+            .catch(err => {
+                alert('나가기 실패: ' + (err.message || JSON.stringify(err)));
+            });
+    }
+
 
     // ────────── 전체 읽음 동기화 핸들러 ──────────────────────────────
 
@@ -254,6 +285,7 @@
         currentSub?.unsubscribe();
         readSub?.unsubscribe();
         readSyncSub?.unsubscribe();
+        memberSub ?.unsubscribe();
     }
 
     /* ───────── 메시지 전송 ───────── */


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #156
close #156
## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- 사용자가 채팅방에서 ‘나가기(leave)’ 버튼을 눌러 해당 채팅방 참가를 종료하고,  
- 서버 측에서는 `is_active=false` 처리 후 WebSocket 채널로 남은 멤버 리스트를 브로드캐스트하도록 구현했습니다.

## 📝 PR 유형
어떤 변경 사항이 있나요?
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->
- `ChatRoomCommandService.leaveChatRoom()` 에서 트랜잭션 커밋 후 멤버 브로드캐스트 로직을 추가했습니다.
<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 채팅방 참가자 관리 전용 REST API가 추가되어, 참가자 추가, 강제 퇴장, 자발적 퇴장이 가능합니다.
	- 테스트 웹소켓 페이지에 "채팅방 나가기" 버튼이 추가되어 사용자가 직접 채팅방을 나갈 수 있습니다.

- **버그 수정**
	- 채팅 메시지 삭제 시 예외 발생 시 클라이언트에 에러 메시지를 반환하도록 개선되었습니다.

- **리팩터링**
	- 중복된 채팅방 나가기 메서드가 제거되어 코드가 정리되었습니다.

- **기타**
	- 채팅방 참가자 관련 기존 엔드포인트가 정리되고, 새로운 구조로 이전되었습니다.
	- 테스트 웹소켓 페이지에서 채팅방 멤버 구독 해제 로직이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->