### PR TITLE
fix: 게시글 수정/삭제 시 첨부파일 관련 버그 수정

### DIFF
--- a/src/main/java/team/budderz/buddyspace/domain/attachment/service/PostAttachmentService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/attachment/service/PostAttachmentService.java
@@ -205,9 +205,7 @@ public class PostAttachmentService {
         postAttachmentRepository.deleteAllByPost(post);
 
         // 고아 첨부파일 삭제 (S3 + DB)
-        for (Long orphanAttachmentId : orphanAttachmentIds) {
-            attachmentService.delete(orphanAttachmentId);
-        }
+        attachmentService.deleteAttachments(orphanAttachmentIds);
     }
 
     /**

--- a/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/post/service/PostService.java
@@ -124,8 +124,8 @@ public class PostService {
         }
 
         post.updatePost(request.content(), request.isNotice());
-        // 기존 첨부파일 삭제
-        postAttachmentService.deletePostFiles(post);
+        // 기존 첨부파일 연결 삭제 및 고아 첨부파일 정리
+        postAttachmentService.deletePostAttachmentsForUpdate(post);
         // 새 content 기준으로 첨부파일 재연결
         postAttachmentService.bindAttachmentsToPost(request.content(), post, userId);
 


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #{이슈-번호}
close #{이슈-번호}
## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
게시글 수정/삭제 시 첨부파일 관련 버그 수정
## 📝 PR 유형
FIX
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 게시글 수정 시, 더 이상 사용되지 않는 첨부파일(고아 첨부파일)이 자동으로 삭제되어 저장소와 데이터베이스에서 정리됩니다.  
- **리팩터링**
  - 게시글 첨부파일 삭제 방식이 개선되어, 실제 게시글 내용에 사용된 첨부파일만 유지되고 불필요한 첨부파일은 정리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->