### PR TITLE
Docs(API): 게시글, 댓글, 알림 API Swagger 문서 작성

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/comment/controller/CommentController.java
+++ b/src/main/java/team/budderz/buddyspace/api/comment/controller/CommentController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.comment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,11 +22,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Tag(name = "댓글", description = "댓글 관련 API")
 public class CommentController {
 
     private final CommentService commentService;
 
     // 댓글 생성
+    @Operation(summary = "댓글 생성", description = "게시글에 댓글을 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "댓글 생성 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponse.class)))
     @PostMapping("/groups/{groupId}/posts/{postId}/comments")
     public BaseResponse<CommentResponse> saveComment (
             @PathVariable Long groupId,
@@ -36,6 +45,9 @@ public class CommentController {
     }
 
     // 대댓글 생성
+    @Operation(summary = "대댓글 생성", description = "댓글에 대댓글을 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "대댓글 생성 성공",
+            content = @Content(schema = @Schema(implementation = RecommentResponse.class)))
     @PostMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
     public BaseResponse<RecommentResponse> saveComment (
             @PathVariable Long groupId,
@@ -51,6 +63,9 @@ public class CommentController {
     }
 
     // 댓글 수정 (대댓글 포함)
+    @Operation(summary = "댓글 수정", description = "댓글 또는 대댓글을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "댓글 수정 성공",
+            content = @Content(schema = @Schema(implementation = CommentResponse.class)))
     @PatchMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
     public BaseResponse<CommentResponse> updateComment (
             @PathVariable Long groupId,
@@ -65,6 +80,9 @@ public class CommentController {
     }
 
      // 댓글 삭제
+     @Operation(summary = "댓글 삭제", description = "댓글 또는 대댓글을 삭제합니다.")
+     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공",
+             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
     public BaseResponse<String> deletecomment (
             @PathVariable Long groupId,
@@ -78,6 +96,9 @@ public class CommentController {
     }
 
     // 대댓글 조회
+    @Operation(summary = "대댓글 조회", description = "특정 댓글에 대한 대댓글 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "대댓글 조회 성공",
+            content = @Content(schema = @Schema(implementation = FindsRecommentResponse.class)))
     @GetMapping("/groups/{groupId}/posts/{postId}/comments/{commentId}")
     public BaseResponse<List<FindsRecommentResponse>> findsRecomment(
             @PathVariable Long groupId,

--- a/src/main/java/team/budderz/buddyspace/api/notification/controller/NotificationController.java
+++ b/src/main/java/team/budderz/buddyspace/api/notification/controller/NotificationController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.notification.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,11 +18,15 @@ import team.budderz.buddyspace.global.security.UserAuth;
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
+@Tag(name = "알림", description = "알림 관련 API")
 public class NotificationController {
 
     private final NotificationService notificationService;
 
     // 알림 전체 조회
+    @Operation(summary = "알림 전체 조회", description = "사용자의 알림 목록을 페이지네이션 형태로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "알림 조회 성공",
+            content = @Content(schema = @Schema(implementation = NotificationResponse.class)))
     @GetMapping
     public BaseResponse<Page<NotificationResponse>> findsNotice (
             @AuthenticationPrincipal UserAuth userAuth,
@@ -28,6 +37,9 @@ public class NotificationController {
     }
 
     // 알림 읽음 처리
+    @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
+    @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/{notificationId}/read")
     public BaseResponse<Void> readNotification(
             @PathVariable Long notificationId,
@@ -38,6 +50,9 @@ public class NotificationController {
     }
 
     // 알림 개수 조회
+    @Operation(summary = "안 읽은 알림 개수 조회", description = "사용자의 읽지 않은 알림 개수를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "알림 개수 조회 성공",
+            content = @Content(schema = @Schema(implementation = Long.class)))
     @GetMapping("/notice-count")
     public BaseResponse<Long> countUnreadNotification(
             @AuthenticationPrincipal UserAuth userAuth

--- a/src/main/java/team/budderz/buddyspace/api/post/controller/PostController.java
+++ b/src/main/java/team/budderz/buddyspace/api/post/controller/PostController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.post.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,11 +21,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Tag(name = "게시글", description = "게시글 관련 API")
 public class PostController {
 
     private final PostService postService;
 
     // 게시글 생성
+    @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 생성 성공",
+            content = @Content(schema = @Schema(implementation = SavePostResponse.class)))
     @PostMapping("/groups/{groupId}/posts")
     public BaseResponse<SavePostResponse> savePost (
             @PathVariable Long groupId,
@@ -33,6 +42,9 @@ public class PostController {
     }
 
     // 게시글 수정
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 수정 성공",
+            content = @Content(schema = @Schema(implementation = UpdatePostResponse.class)))
     @PatchMapping("/groups/{groupId}/posts/{postId}")
     public BaseResponse<UpdatePostResponse> updatePost (
             @PathVariable Long groupId,
@@ -46,6 +58,9 @@ public class PostController {
     }
 
     // 게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/groups/{groupId}/posts/{postId}")
     public BaseResponse<String> deletePost (
             @PathVariable Long groupId,
@@ -58,6 +73,9 @@ public class PostController {
     }
 
     // 게시글 전체 조회
+    @Operation(summary = "게시글 전체 조회", description = "해당 그룹의 전체 게시글을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 조회 성공",
+            content = @Content(schema = @Schema(implementation = FindsPostResponse.class)))
     @GetMapping("/groups/{groupId}/posts")
     public BaseResponse<List<FindsPostResponse>> findsPost (
             @PathVariable Long groupId,
@@ -68,6 +86,9 @@ public class PostController {
     }
 
     // 게시글 공지 조회(내용 일부)
+    @Operation(summary = "공지 게시글 요약 조회", description = "공지 게시글의 요약 내용을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "공지 게시글 요약 조회 성공",
+            content = @Content(schema = @Schema(implementation = FindsNoticePostResponse.class)))
     @GetMapping("/groups/{groupId}/posts-notice")
     public BaseResponse<List<FindsNoticePostResponse>> findNoticePostSummaries(
             @PathVariable Long groupId
@@ -77,6 +98,9 @@ public class PostController {
     }
 
     // 게시글 공지 조회
+    @Operation(summary = "공지 게시글 전체 조회", description = "공지 게시글 전체 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "공지 게시글 전체 조회 성공",
+            content = @Content(schema = @Schema(implementation = FindsPostResponse.class)))
     @GetMapping("/groups/{groupId}/posts/notice")
     public BaseResponse<List<FindsPostResponse>> findsNoticePost (
             @PathVariable Long groupId
@@ -86,6 +110,9 @@ public class PostController {
     }
 
     // 게시글 상세 조회
+    @Operation(summary = "게시글 상세 조회", description = "특정 게시글의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = FindPostResponse.class)))
     @GetMapping("/groups/{groupId}/posts/{postId}")
     public BaseResponse<FindPostResponse> findPost(
             @PathVariable Long groupId,


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #183
close #183
## 📌 개요
- 게시글, 댓글, 알림 API에 대한 Swagger 문서를 추가하여 API 명세를 자동화
## 📝 PR 유형
- 게시글 API Swagger 문서 작성 (`docs`)
- 댓글 API Swagger 문서 작성 (`docs`)
- 알림 API Swagger 문서 작성 (`docs`)
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Swagger 문서가 정상적으로 표시되고 각 API의 설명 및 파라미터 정보가 명확히 작성되어 있습니다.
- [x] Swagger UI에서 게시글, 댓글, 알림 API를 확인하고 테스트할 수 있습니다.
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 댓글, 알림, 게시글 관련 API에 대한 Swagger 문서가 개선되었습니다. 각 컨트롤러와 메서드에 한글 요약 및 설명, 응답 스키마 정보가 추가되어 API 문서 확인이 더욱 편리해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->