### PR TITLE
docs: 사용자, 동네 인증, 모임, 멤버십, 미션 등 Swagger 적용 / feat: 고아 첨부파일 스케줄 적용

### DIFF
--- a/src/main/java/team/budderz/buddyspace/api/attachment/controller/AttachmentController.java
+++ b/src/main/java/team/budderz/buddyspace/api/attachment/controller/AttachmentController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.attachment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import team.budderz.buddyspace.api.attachment.response.AttachmentResponse;
@@ -11,34 +16,51 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/attachments")
 @RequiredArgsConstructor
+@Tag(name = "첨부파일 관리", description = "첨부파일 관련 API")
 public class AttachmentController {
 
     private final AttachmentService attachmentService;
 
+    @Operation(summary = "첨부파일 상세 정보 조회", description = "첨부파일의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "첨부파일 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/{attachmentId}")
     public BaseResponse<AttachmentResponse> getAttachmentDetail(@PathVariable Long attachmentId) {
         AttachmentResponse response = attachmentService.getAttachmentDetail(attachmentId);
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "첨부파일 다운로드 URL 생성", description = "첨부파일의 다운로드 URL을 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "첨부파일 다운로드 URL 생성 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/{attachmentId}/download")
     public BaseResponse<String> download(@PathVariable Long attachmentId) {
         String downloadUrl = attachmentService.getDownloadUrl(attachmentId);
         return new BaseResponse<>(downloadUrl);
     }
 
+    @Operation(summary = "첨부파일 삭제", description = "특정 첨부파일을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "첨부파일 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/{attachmentId}")
     public BaseResponse<Void> deleteAttachment(@PathVariable Long attachmentId) {
         attachmentService.delete(attachmentId);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "첨부파일 일괄 삭제", description = "첨부파일 식별자를 리스트로 받아 일괄 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "첨부파일 일괄 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping
     public BaseResponse<Void> deleteAttachments(@RequestBody List<Long> attachmentIds) {
         attachmentService.deleteAttachments(attachmentIds);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "고아 첨부파일 일괄 삭제",
+            description = "사용자, 모임, 게시글에서 사용되지 않는 고아 첨부파일을 일괄 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "고아 첨부파일 일괄 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/orphans")
     public BaseResponse<Integer> deleteOrphanAttachments() {
         Integer deleteSize = attachmentService.deleteOrphanAttachments();

--- a/src/main/java/team/budderz/buddyspace/api/attachment/controller/PostAttachmentController.java
+++ b/src/main/java/team/budderz/buddyspace/api/attachment/controller/PostAttachmentController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.attachment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -14,10 +19,15 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/groups/{groupId}")
 @RequiredArgsConstructor
+@Tag(name = "모임 내 첨부파일 관리", description = "모임 내 첨부파일 관련 API")
 public class PostAttachmentController {
 
     private final PostAttachmentService postAttachmentService;
 
+    @Operation(summary = "게시글 작성 중 첨부파일 업로드",
+            description = "게시글 작성 중 파일이 첨부되었을 때 호출됩니다. 첨부된 파일을 즉시 업로드합니다.")
+    @ApiResponse(responseCode = "200", description = "첨부파일 업로드 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/post-files")
     public BaseResponse<AttachmentResponse> uploadPostFiles(@PathVariable Long groupId,
                                                             @RequestPart("file") MultipartFile file,
@@ -28,6 +38,9 @@ public class PostAttachmentController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 사진첩 조회", description = "특정 모임의 모든 게시글에 첨부된 사진과 영상 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 사진첩 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/albums")
     public BaseResponse<List<AttachmentResponse>> findGroupAlbum(@PathVariable Long groupId,
                                                                  @RequestParam(required = false) String type,

--- a/src/main/java/team/budderz/buddyspace/api/auth/controller/AuthController.java
+++ b/src/main/java/team/budderz/buddyspace/api/auth/controller/AuthController.java
@@ -1,27 +1,37 @@
 package team.budderz.buddyspace.api.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import team.budderz.buddyspace.api.auth.response.TokenResponse;
 import team.budderz.buddyspace.domain.auth.service.AuthService;
-import team.budderz.buddyspace.domain.user.exception.UserException;
 import team.budderz.buddyspace.global.response.BaseResponse;
-import team.budderz.buddyspace.global.security.JwtUtil;
-import team.budderz.buddyspace.global.util.RedisUtil;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/token")
+@Tag(name = "사용자 인증 관리", description = "사용자 인증 관련 API")
 public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 새로운 액세스 토큰을 재발급합니다.")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/refresh")
     public BaseResponse<TokenResponse> reissueToken(
             @CookieValue(name = "refreshToken", required = false) String refreshToken,
             HttpServletResponse response
     ) {
-        return new BaseResponse<>(authService.reissueToken(refreshToken, response));
+        TokenResponse tokenResponse = authService.reissueToken(refreshToken, response);
+        return new BaseResponse<>(tokenResponse);
     }
 }

--- a/src/main/java/team/budderz/buddyspace/api/group/controller/GroupController.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/controller/GroupController.java
@@ -92,7 +92,8 @@ public class GroupController {
         return new BaseResponse<>(response);
     }
 
-    @Operation(summary = "동네 인증 기반 가입 제한 설정", description = "동네 인증 기반으로 오프라인 모임 가입 제한을 설정합니다.")
+    @Operation(summary = "동네 인증 기반 가입 제한 설정",
+            description = "오프라인 모임의 경우, 사용자의 동네 인증 여부에 따라 모임 가입 요청 가능 여부를 설정할 수 있습니다.")
     @ApiResponse(responseCode = "200", description = "동네 인증 기반 가입 제한 설정 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/{groupId}/neighborhood-auth-required")
@@ -135,7 +136,7 @@ public class GroupController {
         return new BaseResponse<>(responses);
     }
 
-    @Operation(summary = "내가 가입 요청한 모임 목록 조회", description = "내가 가입 요청한 모임 목록을 조회합니다.")
+    @Operation(summary = "내가 가입 요청한 모임 목록 조회", description = "로그인한 사용자가 가입 요청한 모임 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/my-requested")
@@ -164,7 +165,8 @@ public class GroupController {
         return new BaseResponse<>(responses);
     }
 
-    @Operation(summary = "오프라인 모임 목록 조회", description = "오프라인 모임을 사용자 동네, 정렬 기준, 관심사 기반으로 조회합니다.")
+    @Operation(summary = "오프라인 모임 목록 조회",
+            description = "오프라인 모임을 로그인한 사용자의 동네, 정렬 기준, 관심사 기반으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/off")
@@ -181,7 +183,7 @@ public class GroupController {
         return new BaseResponse<>(responses);
     }
 
-    @Operation(summary = "모임 이름 검색", description = "모임 이름 키워드로 모임을 검색합니다.")
+    @Operation(summary = "모임 이름 검색", description = "이름 키워드로 모임을 검색합니다.")
     @ApiResponse(responseCode = "200", description = "검색 성공",
             content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/search")

--- a/src/main/java/team/budderz/buddyspace/api/group/controller/GroupInviteController.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/controller/GroupInviteController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.group.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -11,10 +16,14 @@ import team.budderz.buddyspace.global.security.UserAuth;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups/{groupId}/invites")
+@Tag(name = "모임 초대 링크 관리", description = "모임 초대 링크 관련 API")
 public class GroupInviteController {
 
     private final GroupInviteService groupInviteService;
 
+    @Operation(summary = "모임 초대 링크 생성", description = "모임의 초대 링크를 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 초대 링크 생성 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping
     public BaseResponse<GroupInviteResponse> updateInviteLink(@PathVariable Long groupId,
                                                               @AuthenticationPrincipal UserAuth userAuth) {
@@ -24,6 +33,9 @@ public class GroupInviteController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 초대 링크 조회", description = "모임의 초대 링크를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 초대 링크 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping
     public BaseResponse<GroupInviteResponse> findInviteLink(@PathVariable Long groupId,
                                                             @AuthenticationPrincipal UserAuth userAuth) {
@@ -33,6 +45,9 @@ public class GroupInviteController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "초대 링크 삭제", description = "모임의 초대 링크를 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 초대 링크 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping
     public BaseResponse<GroupInviteResponse> deleteInviteLink(@PathVariable Long groupId,
                                                               @AuthenticationPrincipal UserAuth userAuth) {

--- a/src/main/java/team/budderz/buddyspace/api/group/controller/GroupPermissionController.java
+++ b/src/main/java/team/budderz/buddyspace/api/group/controller/GroupPermissionController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.group.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,10 +23,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups/{groupId}/permissions")
+@Tag(name = "모임 기능별 권한 관리", description = "모임 기능별 권한 관련 API")
 public class GroupPermissionController {
 
     private final GroupPermissionService permissionService;
 
+    @Operation(summary = "모임 기능별 권한 설정", description = "모임의 기능별 접근 권한을 설정합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 기능별 접근 권한 설정 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping
     public BaseResponse<GroupPermissionResponse> updateGroupPermission(
             @PathVariable Long groupId,
@@ -34,6 +43,9 @@ public class GroupPermissionController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 기능별 권한 조회", description = "모임의 기능별 접근 권한을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 기능별 접근 권한 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping
     public BaseResponse<GroupPermissionResponse> findGroupPermissions(
             @PathVariable Long groupId,

--- a/src/main/java/team/budderz/buddyspace/api/membership/controller/MembershipController.java
+++ b/src/main/java/team/budderz/buddyspace/api/membership/controller/MembershipController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.membership.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,10 +19,15 @@ import team.budderz.buddyspace.global.security.UserAuth;
 @RestController
 @RequestMapping("/api/groups/{groupId}")
 @RequiredArgsConstructor
+@Tag(name = "모임 멤버 관리", description = "모임 멤버 관련 API")
 public class MembershipController {
 
     private final MembershipService membershipService;
 
+    @Operation(summary = "특정 모임에 가입된 정보 조회",
+            description = "로그인한 사용자가 가입된 특정 모임의 가입 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "특정 모임에 가입된 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/membership")
     public BaseResponse<MemberResponse> findMyMembership(@PathVariable Long groupId,
                                                          @AuthenticationPrincipal UserAuth userAuth) {
@@ -28,6 +38,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 가입 요청", description = "모임에 가입을 요청합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 가입 요청 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/members/requests")
     public BaseResponse<MembershipResponse> requestJoin(@PathVariable Long groupId,
                                                         @AuthenticationPrincipal UserAuth userAuth) {
@@ -37,6 +50,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 가입 요청 취소", description = "모임 가입 요청을 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 가입 요청 취소 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/cancel-requests")
     public BaseResponse<MembershipResponse> cancelRequest(@PathVariable Long groupId,
                                                           @AuthenticationPrincipal UserAuth userAuth) {
@@ -46,6 +62,9 @@ public class MembershipController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "모임 가입 요청 승인", description = "모임 가입 요청을 승인합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 가입 요청 승인 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/members/{memberId}/approve")
     public BaseResponse<MembershipResponse> approveMember(@PathVariable Long groupId,
                                                           @PathVariable Long memberId,
@@ -56,6 +75,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 가입 요청 거절", description = "모임 가입 요청을 거절합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 가입 요청 거절 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/members/{memberId}/reject")
     public BaseResponse<Void> rejectMember(@PathVariable Long groupId,
                                            @PathVariable Long memberId,
@@ -66,6 +88,9 @@ public class MembershipController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "모임 멤버 강제 탈퇴", description = "모임의 특정 멤버를 강제 탈퇴합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 멤버 강제 탈퇴 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/members/{memberId}/expel")
     public BaseResponse<Void> expelMember(@PathVariable Long groupId,
                                           @PathVariable Long memberId,
@@ -76,6 +101,9 @@ public class MembershipController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "모임 멤버 차단", description = "모임의 특정 멤버를 차단합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 멤버 차단 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/members/{memberId}/block")
     public BaseResponse<MembershipResponse> blockMember(@PathVariable Long groupId,
                                                         @PathVariable Long memberId,
@@ -86,6 +114,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 차단 멤버 차단 해제", description = "모임에서 차단된 멤버의 차단을 해제합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 차단 멤버 차단 해제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/members/{memberId}/unblock")
     public BaseResponse<Void> unblockMember(@PathVariable Long groupId,
                                             @PathVariable Long memberId,
@@ -96,6 +127,9 @@ public class MembershipController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "모임 탈퇴", description = "가입된 모임에서 탈퇴합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 탈퇴 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/withdraw")
     public BaseResponse<Void> withdrawGroup(@PathVariable Long groupId,
                                             @AuthenticationPrincipal UserAuth userAuth) {
@@ -105,6 +139,9 @@ public class MembershipController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "모임 멤버 권한 설정", description = "모임 멤버의 권한을 설정합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 멤버 권한 설정 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/members/{memberId}/role")
     public BaseResponse<MembershipResponse> updateMemberRole(@PathVariable Long groupId,
                                                              @PathVariable Long memberId,
@@ -116,6 +153,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임 리더 위임", description = "모임의 리더를 위임합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 리더 위임 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/members/{memberId}/delegate")
     public BaseResponse<MembershipResponse> delegateLeader(@PathVariable Long groupId,
                                                            @PathVariable Long memberId,
@@ -126,6 +166,9 @@ public class MembershipController {
         return new BaseResponse<>(responses);
     }
 
+    @Operation(summary = "모임에 가입된 멤버 목록 조회", description = "특정 모임에 가입 상태인 멤버 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임에 가입된 멤버 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/members")
     public BaseResponse<MembershipResponse> findApprovedMembers(@PathVariable Long groupId,
                                                                 @AuthenticationPrincipal UserAuth userAuth) {
@@ -135,6 +178,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "가입 요청한 모임 목록 조회", description = "로그인한 사용자가 가입 요청한 모임 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "가입 요청한 모임 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/members/requested")
     public BaseResponse<MembershipResponse> findRequestedMembers(@PathVariable Long groupId,
                                                                  @AuthenticationPrincipal UserAuth userAuth) {
@@ -144,6 +190,9 @@ public class MembershipController {
         return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "모임에 차단된 멤버 목록 조회", description = "특정 모임에서 차단된 멤버 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임에 차단된 멤버 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/members/blocked")
     public BaseResponse<MembershipResponse> findBlockedMembers(@PathVariable Long groupId,
                                                                @AuthenticationPrincipal UserAuth userAuth) {

--- a/src/main/java/team/budderz/buddyspace/api/membership/controller/MembershipInviteController.java
+++ b/src/main/java/team/budderz/buddyspace/api/membership/controller/MembershipInviteController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.membership.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -11,10 +16,15 @@ import team.budderz.buddyspace.global.security.UserAuth;
 @RestController
 @RequestMapping("/api/invites")
 @RequiredArgsConstructor
+@Tag(name = "모임 초대 관리", description = "모임 초대 관련 API")
 public class MembershipInviteController {
 
     private final MembershipService membershipService;
 
+    @Operation(summary = "초대 링크로 모임 가입",
+            description = "로그인한 사용자가 초대 링크를 통해 특정 모임에 가입합니다.")
+    @ApiResponse(responseCode = "200", description = "초대 링크로 모임 가입 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping
     public BaseResponse<MembershipResponse> inviteJoin(@RequestParam String code,
                                                        @AuthenticationPrincipal UserAuth userAuth) {

--- a/src/main/java/team/budderz/buddyspace/api/mission/controller/MissionController.java
+++ b/src/main/java/team/budderz/buddyspace/api/mission/controller/MissionController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.mission.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,52 +24,62 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups/{groupId}/missions")
+@Tag(name = "미션 관리", description = "미션 관련 API")
 public class MissionController {
 
     private final MissionService missionService;
 
+    @Operation(summary = "미션 생성", description = "새로운 미션을 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 생성 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping
-    public BaseResponse<SaveMissionResponse> saveMission(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @Valid @RequestBody SaveMissionRequest request
-    ) {
-        return new BaseResponse<>(missionService.saveMission(userAuth.getUserId(), groupId, request));
+    public BaseResponse<SaveMissionResponse> saveMission(@AuthenticationPrincipal UserAuth userAuth,
+                                                         @PathVariable Long groupId,
+                                                         @Valid @RequestBody SaveMissionRequest request) {
+        SaveMissionResponse response = missionService.saveMission(userAuth.getUserId(), groupId, request);
+        return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "미션 정보 수정", description = "기존 미션의 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 정보 수정 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/{missionId}")
-    public BaseResponse<UpdateMissionResponse> updateMission(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long missionId,
-            @Valid @RequestBody UpdateMissionRequest request
-    ) {
-        return new BaseResponse<>(missionService.updateMission(userAuth.getUserId(), groupId, missionId, request));
+    public BaseResponse<UpdateMissionResponse> updateMission(@AuthenticationPrincipal UserAuth userAuth,
+                                                             @PathVariable Long groupId,
+                                                             @PathVariable Long missionId,
+                                                             @Valid @RequestBody UpdateMissionRequest request) {
+        UpdateMissionResponse response =
+                missionService.updateMission(userAuth.getUserId(), groupId, missionId, request);
+        return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "미션 삭제", description = "특정 미션을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/{missionId}")
-    public BaseResponse<Void> deleteMission(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long missionId
-    ) {
+    public BaseResponse<Void> deleteMission(@AuthenticationPrincipal UserAuth userAuth,
+                                            @PathVariable Long groupId,
+                                            @PathVariable Long missionId) {
         missionService.deleteMission(userAuth.getUserId(), groupId, missionId);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "미션 목록 조회", description = "모임의 미션 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping
-    public BaseResponse<List<MissionResponse>> findMissions(
-            @PathVariable Long groupId
-    ) {
-        return new BaseResponse<>(missionService.findMissions(groupId));
+    public BaseResponse<List<MissionResponse>> findMissions(@PathVariable Long groupId) {
+        List<MissionResponse> responses = missionService.findMissions(groupId);
+        return new BaseResponse<>(responses);
     }
 
+    @Operation(summary = "미션 상세 조회", description = "미션의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/{missionId}")
-    public BaseResponse<MissionDetailResponse> findMissionDetail(
-            @PathVariable Long groupId,
-            @PathVariable Long missionId
-    ) {
-        return new BaseResponse<>(missionService.findMissionDetail(groupId, missionId));
+    public BaseResponse<MissionDetailResponse> findMissionDetail(@PathVariable Long groupId,
+                                                                 @PathVariable Long missionId) {
+        MissionDetailResponse response = missionService.findMissionDetail(groupId, missionId);
+        return new BaseResponse<>(response);
     }
-
 }

--- a/src/main/java/team/budderz/buddyspace/api/missionpost/controller/MissionPostController.java
+++ b/src/main/java/team/budderz/buddyspace/api/missionpost/controller/MissionPostController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.missionpost.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,58 +21,66 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups/{groupId}/missions/{missionId}/posts")
+@Tag(name = "미션 인증 관리", description = "미션 인증 관련 API")
 public class MissionPostController {
 
     private final MissionPostService missionPostService;
 
+    @Operation(summary = "미션 인증 글 생성", description = "새로운 미션 인증 글을 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 인증 글 생성 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping
-    public BaseResponse<Void> saveMissionPost(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long missionId,
-            @Valid @RequestBody MissionPostRequest request
-    ) {
+    public BaseResponse<Void> saveMissionPost(@AuthenticationPrincipal UserAuth userAuth,
+                                              @PathVariable Long groupId,
+                                              @PathVariable Long missionId,
+                                              @Valid @RequestBody MissionPostRequest request) {
         missionPostService.saveMissionPost(userAuth.getUserId(), groupId, missionId, request);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "미션 인증 글 수정", description = "기존의 미션 인증 글을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 인증 글 수정 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/{postId}")
-    public BaseResponse<Void> updateMissionPost(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long missionId,
-            @PathVariable Long postId,
-            @Valid @RequestBody MissionPostRequest request
-    ) {
+    public BaseResponse<Void> updateMissionPost(@AuthenticationPrincipal UserAuth userAuth,
+                                                @PathVariable Long groupId,
+                                                @PathVariable Long missionId,
+                                                @PathVariable Long postId,
+                                                @Valid @RequestBody MissionPostRequest request) {
         missionPostService.updateMissionPost(userAuth.getUserId(), groupId, missionId, postId, request);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "미션 인증 글 삭제", description = "특정 미션 인증 글을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 인증 글 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/{postId}")
-    public BaseResponse<Void> deleteMissionPost(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long groupId,
-            @PathVariable Long missionId,
-            @PathVariable Long postId
-    ) {
+    public BaseResponse<Void> deleteMissionPost(@AuthenticationPrincipal UserAuth userAuth,
+                                                @PathVariable Long groupId,
+                                                @PathVariable Long missionId,
+                                                @PathVariable Long postId) {
         missionPostService.deleteMissionPost(userAuth.getUserId(), groupId, missionId, postId);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "특정 미션의 인증 글 목록 조회", description = "특정 미션의 인증 글 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "특정 미션의 인증 글 목록 조회",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping
-    public BaseResponse<List<MissionPostResponse>> findMissionPosts(
-            @PathVariable Long groupId,
-            @PathVariable Long missionId
-    ) {
-        return new BaseResponse<>(missionPostService.findMissionPosts(groupId, missionId));
+    public BaseResponse<List<MissionPostResponse>> findMissionPosts(@PathVariable Long groupId,
+                                                                    @PathVariable Long missionId) {
+        List<MissionPostResponse> responses = missionPostService.findMissionPosts(groupId, missionId);
+        return new BaseResponse<>(responses);
     }
 
+    @Operation(summary = "미션 인증 글 상세 조회", description = "특정 미션 인증 글의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "미션 인증 글 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/{postId}")
-    public BaseResponse<MissionPostDetailResponse> findMissionPostDetail(
-            @PathVariable Long groupId,
-            @PathVariable Long missionId,
-            @PathVariable Long postId
-    ) {
-        return new BaseResponse<>(missionPostService.findMissionPostDetail(groupId, missionId, postId));
+    public BaseResponse<MissionPostDetailResponse> findMissionPostDetail(@PathVariable Long groupId,
+                                                                         @PathVariable Long missionId,
+                                                                         @PathVariable Long postId) {
+        MissionPostDetailResponse response = missionPostService.findMissionPostDetail(groupId, missionId, postId);
+        return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/team/budderz/buddyspace/api/neighborhood/controller/NeighborhoodController.java
+++ b/src/main/java/team/budderz/buddyspace/api/neighborhood/controller/NeighborhoodController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.neighborhood.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -12,32 +17,37 @@ import team.budderz.buddyspace.global.security.UserAuth;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/neighborhoods")
-
+@Tag(name = "동네 인증 관리", description = "동네 인증 관련 API")
 public class NeighborhoodController {
 
     private final NeighborhoodService neighborhoodService;
 
+    @Operation(summary = "사용자 동네 인증", description = "로그인한 사용자의 현재 위치를 기반으로 동네 정보를 저장합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 동네 인증 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping
-    public BaseResponse<NeighborhoodResponse> saveNeighborhood(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @RequestBody NeighborhoodRequest request
-    ) {
-        return new BaseResponse<>(neighborhoodService.saveNeighborhood(userAuth.getUserId(), request));
+    public BaseResponse<NeighborhoodResponse> saveNeighborhood(@AuthenticationPrincipal UserAuth userAuth,
+                                                               @RequestBody NeighborhoodRequest request) {
+        NeighborhoodResponse response = neighborhoodService.saveNeighborhood(userAuth.getUserId(), request);
+        return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "사용자 동네 인증 정보 조회", description = "로그인한 사용자의 동네 인증 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 동네 인증 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/{neighborhoodId}")
-    public BaseResponse<NeighborhoodResponse> findNeighborhood(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long neighborhoodId
-    ) {
-        return new BaseResponse<>(neighborhoodService.findNeighborhood(userAuth.getUserId(), neighborhoodId));
+    public BaseResponse<NeighborhoodResponse> findNeighborhood(@AuthenticationPrincipal UserAuth userAuth,
+                                                               @PathVariable Long neighborhoodId) {
+        NeighborhoodResponse response = neighborhoodService.findNeighborhood(userAuth.getUserId(), neighborhoodId);
+        return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "사용자 동네 인증 정보 삭제", description = "로그인한 사용자의 동네 인증 정보를 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 동네 인증 정보 삭제 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping("/{neighborhoodId}")
-    public BaseResponse<Void> deleteNeighborhood(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @PathVariable Long neighborhoodId
-    ) {
+    public BaseResponse<Void> deleteNeighborhood(@AuthenticationPrincipal UserAuth userAuth,
+                                                 @PathVariable Long neighborhoodId) {
         neighborhoodService.deleteNeighborhood(userAuth.getUserId(), neighborhoodId);
         return new BaseResponse<>(null);
     }

--- a/src/main/java/team/budderz/buddyspace/api/user/controller/UserController.java
+++ b/src/main/java/team/budderz/buddyspace/api/user/controller/UserController.java
@@ -1,5 +1,10 @@
 package team.budderz.buddyspace.api.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -20,23 +25,33 @@ import team.budderz.buddyspace.global.security.UserAuth;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
+@Tag(name = "사용자 관리", description = "사용자 관련 API")
 public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "회원가입 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/signup")
     public BaseResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
-        return new BaseResponse<>(userService.signup(signupRequest));
+        SignupResponse response = userService.signup(signupRequest);
+        return new BaseResponse<>(response);
     }
 
+    @Operation(summary = "로그인", description = "사용자 로그인을 수행합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/login")
-    public BaseResponse<TokenResponse> login(
-            @RequestBody LoginRequest loginRequest,
-            HttpServletResponse response
-    ) {
-        return new BaseResponse<>(userService.login(loginRequest, response));
+    public BaseResponse<TokenResponse> login(@RequestBody LoginRequest loginRequest,
+                                             HttpServletResponse response) {
+        TokenResponse tokenResponse = userService.login(loginRequest, response);
+        return new BaseResponse<>(tokenResponse);
     }
 
+    @Operation(summary = "로그아웃", description = "현재 로그인한 사용자를 로그아웃합니다.")
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/logout")
     public BaseResponse<Void> logout(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
@@ -45,6 +60,9 @@ public class UserController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "사용자 정보 수정", description = "사용자의 프로필 정보를 수정합니다. (쿠키로 인증된 사용자만 수행 가능)")
+    @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<UserUpdateResponse> updateUser(
             @AuthenticationPrincipal UserAuth userAuth,
@@ -53,11 +71,14 @@ public class UserController {
             @RequestPart("request") @Valid UserUpdateRequest request,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
-        return new BaseResponse<>(userService.updateUser(
-                userAuth.getUserId(), passwordToken, response, request, profileImage
-        ));
+        UserUpdateResponse updateResponse =
+                userService.updateUser(userAuth.getUserId(), passwordToken, response, request, profileImage);
+        return new BaseResponse<>(updateResponse);
     }
 
+    @Operation(summary = "비밀번호 변경", description = "사용자의 비밀번호를 변경합니다. (쿠키로 인증된 사용자만 수행 가능)")
+    @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PatchMapping("/password")
     public BaseResponse<Void> updateUserPassword(
             @AuthenticationPrincipal UserAuth userAuth,
@@ -66,10 +87,12 @@ public class UserController {
             @Valid @RequestBody UserPasswordUpdateRequest updateRequest
     ) {
         userService.updateUserPassword(userAuth.getUserId(), passwordToken, response, updateRequest);
-
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "회원 탈퇴", description = "사용자 계정을 삭제합니다. (쿠키로 인증된 사용자만 수행 가능)")
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @DeleteMapping
     public BaseResponse<Void> deleteUser(
             @AuthenticationPrincipal UserAuth userAuth,
@@ -77,22 +100,26 @@ public class UserController {
             HttpServletResponse response
     ) {
         userService.deleteUser(userAuth.getUserId(), passwordToken, response);
-
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "비밀번호 인증", description = "사용자 정보 및 비밀번호 변경, 탈퇴 전에 비밀번호를 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "비밀번호 인증 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @PostMapping("/verify-password")
-    public BaseResponse<Void> verifyPassword(
-            @AuthenticationPrincipal UserAuth userAuth,
-            @Valid @RequestBody PasswordRequest request,
-            HttpServletResponse response
-    ) {
+    public BaseResponse<Void> verifyPassword(@AuthenticationPrincipal UserAuth userAuth,
+                                             @Valid @RequestBody PasswordRequest request,
+                                             HttpServletResponse response) {
         userService.verifyPassword(userAuth.getUserId(), request, response);
         return new BaseResponse<>(null);
     }
 
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "내 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     @GetMapping("/me")
     public BaseResponse<UserDetailResponse> getMyInfo(@AuthenticationPrincipal UserAuth userAuth) {
-        return new BaseResponse<>(userService.getMyPage(userAuth.getUserId()));
+        UserDetailResponse response = userService.getMyPage(userAuth.getUserId());
+        return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/team/budderz/buddyspace/api/view/TestStaticPageController.java
+++ b/src/main/java/team/budderz/buddyspace/api/view/TestStaticPageController.java
@@ -1,0 +1,30 @@
+package team.budderz.buddyspace.api.view;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class TestStaticPageController {
+
+    @GetMapping("/test/**")
+    public ResponseEntity<Resource> serveHtmlWithoutExtension(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String pathWithoutPrefix = uri.replaceFirst("/test", "");
+        String fullPath = "static/test" + pathWithoutPrefix + ".html";
+
+        Resource resource = new ClassPathResource(fullPath);
+
+        if (!resource.exists()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_HTML)
+                .body(resource);
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/global/config/SchedulingConfig.java
+++ b/src/main/java/team/budderz/buddyspace/global/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package team.budderz.buddyspace.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+    // 스케줄링 기능 활성화
+}

--- a/src/main/java/team/budderz/buddyspace/global/config/SecurityConfig.java
+++ b/src/main/java/team/budderz/buddyspace/global/config/SecurityConfig.java
@@ -47,12 +47,10 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers( // test
                                 "/favicon.ico",
-                                "/test-websocket.html",
                                 "/test/**",
                                 "/js/**",
                                 "/css/**",
-                                "/ws/**",
-                                "/static/**"
+                                "/ws/**"
                         ).permitAll()
                         .requestMatchers( // swagger
                                 "/api-ui",

--- a/src/main/java/team/budderz/buddyspace/global/config/SwaggerConfig.java
+++ b/src/main/java/team/budderz/buddyspace/global/config/SwaggerConfig.java
@@ -24,15 +24,14 @@ public class SwaggerConfig {
 
         Components components = new Components()
                 .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-                        .name(jwtSchemeName)
                         .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));
 
         return new OpenAPI()
                 .info(new Info().title("BUDDY SPACE API")
-                        .description("벗터 API 문서")
-                        .version("v1.0.0"))
+                        .description("프로젝트 벗터 API 문서")
+                        .version("1.0.0"))
                 .addSecurityItem(securityRequirement)
                 .components(components);
     }

--- a/src/main/java/team/budderz/buddyspace/global/config/WebConfig.java
+++ b/src/main/java/team/budderz/buddyspace/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package team.budderz.buddyspace.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/test/**")
+                .addResourceLocations("classpath:/static/test/");
+
+        registry.addResourceHandler("/js/**")
+                .addResourceLocations("classpath:/static/js/");
+
+        registry.addResourceHandler("/css/**")
+                .addResourceLocations("classpath:/static/css/");
+    }
+}

--- a/src/main/java/team/budderz/buddyspace/infra/scheduler/AttachmentCleanupScheduler.java
+++ b/src/main/java/team/budderz/buddyspace/infra/scheduler/AttachmentCleanupScheduler.java
@@ -1,0 +1,22 @@
+package team.budderz.buddyspace.infra.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import team.budderz.buddyspace.domain.attachment.service.AttachmentService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AttachmentCleanupScheduler {
+
+    private final AttachmentService attachmentService;
+
+    @Scheduled(cron = "0 0 20 * * *")
+    public void deleteOrphanAttachmentsDaily() {
+        log.info("고아 첨부파일 삭제 스케줄 시작");
+        Integer deleted = attachmentService.deleteOrphanAttachments();
+        log.info("고아 첨부파일 {}건 삭제 완료", deleted);
+    }
+}

--- a/src/main/resources/static/test/chat.html
+++ b/src/main/resources/static/test/chat.html
@@ -1,4 +1,4 @@
-<!-- test-websocket.html (add read‑receipt logic) -->
+<!-- chat.html (add read‑receipt logic) -->
 <!DOCTYPE html>
 <html lang="ko">
 <head>


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #{이슈-번호}
close #{이슈-번호}
## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
## 📝 PR 유형
어떤 변경 사항이 있나요?
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 모든 REST API 컨트롤러에 OpenAPI(Swagger) 문서화가 추가되어, 각 엔드포인트의 목적과 응답 정보가 명확하게 안내됩니다. 이를 통해 API 명세 확인이 더욱 쉬워집니다.

* **신규 기능**
  * 매일 20시에 고아 첨부파일을 자동으로 정리하는 스케줄러가 도입되었습니다.
  * 스케줄링 기능이 전체 서비스에 활성화되었습니다.
  * `/test/**` 경로에서 정적 HTML 페이지를 제공하는 기능이 추가되었습니다.
  * 정적 리소스(`/test/**`, `/js/**`, `/css/**`)를 서비스하기 위한 리소스 핸들러가 등록되었습니다.

* **개선**
  * API 문서의 설명과 버전 정보가 갱신되었습니다.
  * 테스트 관련 보안 설정에서 일부 경로에 대한 인증 제외가 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->