### PR TITLE
Docs(API): SSE API Swagger 문서 작성

### DIFF
--- a/src/main/java/team/budderz/buddyspace/global/sse/controller/NotificationSseController.java
+++ b/src/main/java/team/budderz/buddyspace/global/sse/controller/NotificationSseController.java
@@ -1,5 +1,9 @@
 package team.budderz.buddyspace.global.sse.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -18,11 +22,20 @@ import java.util.concurrent.TimeUnit;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notifications")
+@Tag(name = "SSE", description = "SSE 관련 API")
 public class NotificationSseController {
 
     private final EmitterRepository emitterRepository;
     private static final Long TIMEOUT = 60 * 60 * 1000L; // 1시간 유지
 
+    @Operation(
+            summary = "SSE 알림 구독",
+            description = """
+        클라이언트가 SSE 연결을 구독합니다. \s
+        `clientId`는 브라우저 탭 또는 클라이언트 고유 식별자로 사용되며, 중복 방지를 위해 사용됩니다. \s
+        연결 후 서버는 `connect`, `heartbeat` 이벤트를 주기적으로 전송합니다."""
+    )
+    @ApiResponse(responseCode = "200", description = "SSE 연결 성공", content = @Content(mediaType = "text/event-stream"))
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(
             @AuthenticationPrincipal UserAuth userAuth,


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #192 
close #192 
## 📌 개요
- SSE 기반 알림 구독 API에 대한 Swagger 문서도 추가
## 📝 PR 유형
- SSE 알림 구독 API 명세 추가 (`docs`)
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] SSE 구독 API 명세가 Swagger 문서에 추가되어 있습니다.
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * SSE 알림 구독 엔드포인트에 대한 OpenAPI(Swagger) 문서가 추가되어, API 명세와 사용 방법을 더욱 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->