### PR TITLE
Refactor(Event): 그룹 가입 알림 이벤트 구조 및 URL 포맷 개선

### DIFF
--- a/src/main/java/team/budderz/buddyspace/domain/membership/event/MembershipEventHandler.java
+++ b/src/main/java/team/budderz/buddyspace/domain/membership/event/MembershipEventHandler.java
@@ -1,6 +1,7 @@
 package team.budderz.buddyspace.domain.membership.event;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -22,16 +23,16 @@ public class MembershipEventHandler {
                 null,
                 null,
                 "가입 요청",
-                event.leaderId().getId(),
-                event.groupId(),
+                event.leader().getId(),
+                event.group().getId(),
                 null,
                 null
         );
 
         notificationService.sendNotice(
                 NotificationType.GROUP_JOIN_REQUEST,
-                event.leaderId(),
-                null,
+                event.leader(),
+                event.group(),
                 args
         );
     }
@@ -41,18 +42,18 @@ public class MembershipEventHandler {
     public void handleMembershipJoinApproved(MembershipJoinApprovedEvent event) {
         NotificationArgs args = new NotificationArgs(
                 null,
-                null,
+                event.group().getName(),
                 "가입 승인",
-                event.requesterId().getId(),
-                event.groupId(),
+                event.requester().getId(),
+                event.group().getId(),
                 null,
                 null
         );
 
         notificationService.sendNotice(
                 NotificationType.GROUP_JOIN_APPROVED,
-                event.requesterId(),
-                null,
+                event.requester(),
+                event.group(),
                 args
         );
     }

--- a/src/main/java/team/budderz/buddyspace/domain/membership/event/MembershipJoinApprovedEvent.java
+++ b/src/main/java/team/budderz/buddyspace/domain/membership/event/MembershipJoinApprovedEvent.java
@@ -1,10 +1,11 @@
 package team.budderz.buddyspace.domain.membership.event;
 
+import team.budderz.buddyspace.infra.database.group.entity.Group;
 import team.budderz.buddyspace.infra.database.user.entity.User;
 
 public record MembershipJoinApprovedEvent(
-        Long groupId,
-        User requesterId,
-        User leaderId
+        Group group,
+        User requester,
+        User leader
     ) {
 }

--- a/src/main/java/team/budderz/buddyspace/domain/membership/event/MembershipJoinRequestedEvent.java
+++ b/src/main/java/team/budderz/buddyspace/domain/membership/event/MembershipJoinRequestedEvent.java
@@ -1,10 +1,11 @@
 package team.budderz.buddyspace.domain.membership.event;
 
+import team.budderz.buddyspace.infra.database.group.entity.Group;
 import team.budderz.buddyspace.infra.database.user.entity.User;
 
 public record MembershipJoinRequestedEvent(
-        Long groupId,
+        Group group,
         User requester,
-        User leaderId
+        User leader
 ) {
 }

--- a/src/main/java/team/budderz/buddyspace/domain/membership/service/MembershipService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/membership/service/MembershipService.java
@@ -104,7 +104,7 @@ public class MembershipService {
         Membership membership = Membership.fromRequest(user, group);
         membershipRepository.save(membership);
 
-        eventPublisher.publishEvent(new MembershipJoinRequestedEvent(group.getId(), user, group.getLeader()));
+        eventPublisher.publishEvent(new MembershipJoinRequestedEvent(group, user, group.getLeader()));
 
         return MembershipResponse.of(group, List.of(membership), profileImageProvider);
     }
@@ -150,7 +150,7 @@ public class MembershipService {
 
         membership.approve();
 
-        eventPublisher.publishEvent(new MembershipJoinApprovedEvent(group.getId(), requester, leader));
+        eventPublisher.publishEvent(new MembershipJoinApprovedEvent(group, requester, leader));
 
         return MembershipResponse.of(group, List.of(membership), profileImageProvider);
     }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
@@ -18,11 +18,12 @@ public class JoinApprovedNotificationTemplate implements NotificationTemplate{
         return "관리자가 가입 요청을 수락했습니다.";
     }
 
+    // 링크 수정 필요
     @Override
     public String generateUrl(NotificationArgs args) {
         if (args == null || args.groupId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("/api/groups/%d", args.groupId());
+        return String.format("groups/%d", args.groupId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
@@ -15,14 +15,15 @@ public class JoinRequestNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateContent(NotificationArgs args) {
-        return String.format("%s 님이 가입 요청을 보냈습니다.", args.senderName());
+        return String.format("%s 님이 %s에 가입 요청을 보냈습니다.", args.senderName(), args.groupName());
     }
 
+    // 링크 수정 필요
     @Override
     public String generateUrl(NotificationArgs args) {
-        if (args == null || args.groupId() == null || args.postId() == null || args.memberId() == null) {
+        if (args == null || args.groupId() == null || args.memberId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("/api/groups/%d/members/%d/approve", args.groupId(), args.memberId());
+        return String.format("groups/%d/setting", args.groupId());
     }
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #195 
close #195
## 📌 개요
- 그룹 가입 요청 및 승인 관련 도메인 이벤트 구조를 개선하고, 알림 핸들러 로직을 정리했습니다.
- 이벤트 전달 시 ID 기반 → 엔티티 기반으로 변경하여 도메인 책임을 명확히 했습니다.
- 알림 메시지 및 URL 포맷을 개선했으며, 향후 명확한 규칙 정립 후 추가 리팩토링이 예정되어 있습니다.
## 📝 PR 유형
- MembershipJoinRequestedEvent, MembershipJoinApprovedEvent 필드 구조 개선
- 그룹 가입 요청/승인 알림 핸들러 로직 리팩토링
- 알림 메시지 및 URL 포맷 개선 (추후 포맷 확정 필요)
- 도메인 이벤트 파라미터를 ID 기반에서 엔티티 기반으로 변경
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 그룹 가입 요청 및 승인 알림이 정상적으로 전송됩니다.
- [x] 이벤트 기반 구조가 엔티티 중심으로 변경되어 로직이 명확해졌습니다.
- [ ] URL 및 메시지 포맷은 추후 재정의 필요 (TODO 주석 확인)
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 그룹 가입 승인 및 요청 알림에 그룹 이름이 표시됩니다.

* **버그 수정**
  * 알림 내 그룹 관련 링크가 보다 직관적인 경로로 변경되었습니다.

* **리팩터링**
  * 알림 및 이벤트 처리에서 단순 ID 대신 전체 그룹 및 사용자 정보가 활용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->