### PR TITLE
feat: 프론트 OAuth2 리다이렉트 대응 및 로그인 성공 처리 방식 수정

### DIFF
--- a/src/main/java/team/budderz/buddyspace/global/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/team/budderz/buddyspace/global/oauth2/handler/OAuth2SuccessHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
@@ -13,21 +14,25 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import team.budderz.buddyspace.api.auth.response.TokenResponse;
-import team.budderz.buddyspace.api.user.response.LoginResponse;
 import team.budderz.buddyspace.global.oauth2.service.CustomOAuth2UserService;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final ObjectMapper objectMapper;
 
+    @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
+
+        log.info("OAuth2 로그인 성공 처리 시작");
 
         TokenResponse tokenResponse = (TokenResponse) RequestContextHolder.getRequestAttributes()
                 .getAttribute(CustomOAuth2UserService.LOGIN_RESPONSE_ATTR, RequestAttributes.SCOPE_REQUEST);
@@ -35,24 +40,109 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String refreshToken = (String) RequestContextHolder.getRequestAttributes()
                 .getAttribute("REFRESH_TOKEN", RequestAttributes.SCOPE_REQUEST);
 
+        log.info("TokenResponse: {}, RefreshToken: {}", tokenResponse != null, refreshToken != null);
+
         if (tokenResponse == null || refreshToken == null) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Token not found");
+            log.error("토큰이 null입니다");
+            response.sendRedirect("http://localhost:3000/auth/callback?error=token_not_found&message=" +
+                    java.net.URLEncoder.encode("토큰 생성에 실패했습니다.", java.nio.charset.StandardCharsets.UTF_8));
             return;
         }
 
+        // RefreshToken을 HttpOnly 쿠키로 설정
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)
                 .sameSite("Lax")
                 .path("/")
                 .maxAge(Duration.ofDays(14))
                 .build();
         response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
+        // TokenResponse에서 accessToken 추출
+        String accessToken = extractAccessToken(tokenResponse);
 
-        String json = objectMapper.writeValueAsString(tokenResponse);
-        response.getWriter().write(json);
+        if (accessToken == null) {
+            log.error("AccessToken 추출 실패");
+            response.sendRedirect("http://localhost:3000/auth/callback?error=token_extraction_failed&message=" +
+                    java.net.URLEncoder.encode("토큰 추출에 실패했습니다.", java.nio.charset.StandardCharsets.UTF_8));
+            return;
+        }
+
+        log.info("AccessToken 추출 성공: {}", accessToken.substring(0, Math.min(20, accessToken.length())) + "...");
+
+        // 프론트엔드로 리다이렉트
+        String redirectUrl = "http://localhost:3000/auth/callback?token=" + accessToken + "&success=true";
+        log.info("리다이렉트 URL: {}", redirectUrl);
+        response.sendRedirect(redirectUrl);
+    }
+
+    private String extractAccessToken(TokenResponse tokenResponse) {
+        try {
+            // TokenResponse 클래스 정보 로깅
+            Class<?> clazz = tokenResponse.getClass();
+            log.info("TokenResponse 클래스: {}", clazz.getName());
+
+            // 모든 필드 출력
+            Field[] fields = clazz.getDeclaredFields();
+            for (Field field : fields) {
+                field.setAccessible(true);
+                try {
+                    Object value = field.get(tokenResponse);
+                    log.info("필드 {}: {}", field.getName(), value);
+                } catch (Exception e) {
+                    log.warn("필드 {} 접근 실패", field.getName());
+                }
+            }
+
+            // 모든 메서드 출력
+            Method[] methods = clazz.getDeclaredMethods();
+            for (Method method : methods) {
+                if (method.getName().startsWith("get") && method.getParameterCount() == 0) {
+                    log.info("Getter 메서드: {}", method.getName());
+                }
+            }
+
+            // 1. getAccessToken() 시도
+            try {
+                Method getAccessToken = clazz.getMethod("getAccessToken");
+                return (String) getAccessToken.invoke(tokenResponse);
+            } catch (Exception e) {
+                log.debug("getAccessToken() 메서드 없음");
+            }
+
+            // 2. getToken() 시도
+            try {
+                Method getToken = clazz.getMethod("getToken");
+                return (String) getToken.invoke(tokenResponse);
+            } catch (Exception e) {
+                log.debug("getToken() 메서드 없음");
+            }
+
+            // 3. accessToken 필드 시도
+            try {
+                Field accessTokenField = clazz.getDeclaredField("accessToken");
+                accessTokenField.setAccessible(true);
+                return (String) accessTokenField.get(tokenResponse);
+            } catch (Exception e) {
+                log.debug("accessToken 필드 없음");
+            }
+
+            // 4. token 필드 시도
+            try {
+                Field tokenField = clazz.getDeclaredField("token");
+                tokenField.setAccessible(true);
+                return (String) tokenField.get(tokenResponse);
+            } catch (Exception e) {
+                log.debug("token 필드 없음");
+            }
+
+            log.error("AccessToken을 추출할 수 있는 방법을 찾지 못했습니다");
+            return null;
+
+        } catch (Exception e) {
+            log.error("AccessToken 추출 중 오류 발생", e);
+            return null;
+        }
     }
 }

--- a/src/main/java/team/budderz/buddyspace/infra/config/WebSocketConfig.java
+++ b/src/main/java/team/budderz/buddyspace/infra/config/WebSocketConfig.java
@@ -43,6 +43,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                         "http://localhost:8080",             // 로컬테스트
                         "https://app.mydomain.com"         // 추후 운영서버
                 )
+                .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,10 @@ spring:
             token-uri: https://oauth2.googleapis.com/token
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
+app:
+  oauth2:
+    redirect-uri: http://localhost:3000/auth/callback
+
 
   servlet:
     multipart:


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #{이슈-번호}
close #{이슈-번호}
## 📌 개요
- OAuth2SuccessHandler 수정: accessToken을 쿼리로 전달, refreshToken은 HttpOnly 쿠키로 설정
- SecurityConfig 수정: OAuth2 로그인 실패 시 프론트로 리다이렉트 처리 추가
- WebSocketConfig 수정: 프론트 테스트를 위한 CORS 전체 허용 (개발용)
- application.yml 수정: app.oauth2.redirect-uri 항목 추가
## 📝 PR 유형
어떤 변경 사항이 있나요?
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * OAuth2 로그인 실패 시 프론트엔드로 에러 정보를 포함하여 리디렉션되는 기능이 추가되었습니다.
  * OAuth2 로그인 성공 시 액세스 토큰을 추출하여 프론트엔드 콜백 URL로 리디렉션하는 방식으로 개선되었습니다.

* **버그 수정**
  * OAuth2 인증 처리 과정에서 토큰이 없을 경우 에러 페이지로 안전하게 리디렉션되도록 오류 처리가 강화되었습니다.

* **설정**
  * WebSocket 및 CORS 설정이 확장되어 모든 오리진에서의 접근이 허용되었습니다.
  * OAuth2 콜백 리디렉션 URI가 환경설정에 추가되었습니다.

* **문서**
  * 주석 및 설명이 일부 정비되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->