### PR TITLE
Fix(Auth): accessToken 및 refreshToken 쿠키 설정 처리

### DIFF
--- a/src/main/java/team/budderz/buddyspace/domain/user/service/UserService.java
+++ b/src/main/java/team/budderz/buddyspace/domain/user/service/UserService.java
@@ -105,14 +105,26 @@ public class UserService {
         // Redis 저장
         redisUtil.setData("RT:" + user.getId(), refreshToken, jwtUtil.getRefreshTokenExpireTime());
 
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        // accessToken 쿠키 설정
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", accessToken)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Lax")
+                .sameSite("None")
+                .path("/")
+                .maxAge(Duration.ofDays(1))
+                .build();
+
+        // refreshToken 쿠키 설정
+        ResponseCookie refreshTokenCookie  = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
                 .path("/")
                 .maxAge(Duration.ofDays(7))
                 .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         return new TokenResponse(accessToken);
     }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #210 
close #210 
## 📌 개요
- 로그인 성공 시 `accessToken`과 `refreshToken`이 모두 쿠키에 저장되도록 수정했습니다.
- 클라이언트에서 별도 저장 없이 인증 흐름을 유지할 수 있도록 개선했습니다.
## 📝 PR 유형
- 인증 처리 로직 수정
- accessToken, refreshToken 쿠키 저장 기능 추가
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 로그인 시 accessToken과 refreshToken이 모두 쿠키에 저장됨을 확인했습니다.
- [x] 쿠키 설정은 httpOnly, secure, sameSite 등을 포함하여 보안 설정을 고려했습니다.

## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그인 시 액세스 토큰과 리프레시 토큰이 각각 별도의 쿠키로 설정됩니다. 두 쿠키 모두 보안 속성이 강화되었으며, 각 쿠키의 만료 기간이 다르게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->