### PR TITLE
Refactor(Notification): 알림 URL 포맷 일관성 개선

### DIFF
--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/CommentNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/CommentNotificationTemplate.java
@@ -20,9 +20,9 @@ public class CommentNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        if (args == null || args.groupId() == null || args.postId() == null || args.commentId() == null) {
+        if (args == null || args.groupId() == null || args.postId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("/api/groups/%d/posts/%d/comments/%d", args.groupId(), args.postId(), args.commentId());
+        return String.format("/meeting/group/%d/posts/%d", args.groupId(), args.postId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinApprovedNotificationTemplate.java
@@ -24,6 +24,6 @@ public class JoinApprovedNotificationTemplate implements NotificationTemplate{
         if (args == null || args.groupId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("groups/%d", args.groupId());
+        return String.format("/meeting/group/%d", args.groupId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/JoinRequestNotificationTemplate.java
@@ -24,6 +24,6 @@ public class JoinRequestNotificationTemplate implements NotificationTemplate{
         if (args == null || args.groupId() == null || args.memberId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("groups/%d/setting", args.groupId());
+        return String.format("/meeting/group/%d/setting", args.groupId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/NoticeNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/NoticeNotificationTemplate.java
@@ -23,6 +23,6 @@ public class NoticeNotificationTemplate implements NotificationTemplate{
         if (args == null || args.groupId() == null || args.postId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("/api/groups/%d/posts/%d", args.groupId(), args.postId());
+        return String.format("/meeting/group/%d/posts/%d", args.groupId(), args.postId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/PostNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/PostNotificationTemplate.java
@@ -23,6 +23,6 @@ public class PostNotificationTemplate implements NotificationTemplate{
         if (args == null || args.groupId() == null || args.postId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("/api/groups/%d/posts/%d", args.groupId(), args.postId());
+        return String.format("/meeting/group/%d/posts/%d", args.groupId(), args.postId());
     }
 }

--- a/src/main/java/team/budderz/buddyspace/domain/notification/template/ReplyNotificationTemplate.java
+++ b/src/main/java/team/budderz/buddyspace/domain/notification/template/ReplyNotificationTemplate.java
@@ -20,9 +20,9 @@ public class ReplyNotificationTemplate implements NotificationTemplate{
 
     @Override
     public String generateUrl(NotificationArgs args) {
-        if (args == null || args.groupId() == null || args.postId() == null || args.commentId() == null) {
+        if (args == null || args.groupId() == null || args.postId() == null) {
             throw new BaseException(NotificationErrorCode.INVALID_NOTIFICATION_ARGUMENT);
         }
-        return String.format("/api/groups/%d/posts/%d/comments/%d", args.groupId(), args.postId(), args.commentId());
+        return String.format("/meeting/group/%d/posts/%d", args.groupId(), args.postId());
     }
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #212 
close #212
## 📌 개요
- 알림(Notification)에서 사용되는 URL 포맷을 수정하여 일관성과 가독성을 높였습니다.
- URL 생성 로직이 통일되어 프론트엔드 라우팅과의 연결이 명확해졌습니다.
## 📝 PR 유형
- 알림 URL 포맷 수정
- 알림 템플릿 및 URL 생성 규칙 정리
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] URL 포맷 수정 후 알림 클릭 시 정상 라우팅되는지 확인했습니다.
- [x] 기존 알림 타입별 URL 포맷과의 충돌 여부 확인 완료
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림에서 제공되는 URL 경로가 일관적으로 `/meeting/group/...` 형식으로 변경되었습니다.
  * 댓글 및 답글 알림의 URL이 더 간단한 경로로 개선되었습니다.
  * 그룹 승인 및 요청 알림의 URL이 새로운 경로로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->