### PR TITLE
fix: SockJS fallback 시 access_token 인증 로직 추가 및 CORS 설정 강화 #219

### DIFF
--- a/src/main/java/team/budderz/buddyspace/global/config/CorsConfigDeploy.java
+++ b/src/main/java/team/budderz/buddyspace/global/config/CorsConfigDeploy.java
@@ -19,12 +19,14 @@ public class CorsConfigDeploy implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOriginPatterns("https://budderz.co.kr", "https://api.budderz.co.kr")
-            .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
-            .exposedHeaders("Authorization", "Set-Cookie")
-            .allowCredentials(true)
-            .maxAge(3600);
+                .allowedOriginPatterns("https://budderz.co.kr", "https://api.budderz.co.kr")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "Accept")
+                .exposedHeaders("Authorization", "Set-Cookie")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
+
 
     // @Bean
     // public CorsConfigurationSource corsConfigurationSource() {


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
resolves #{이슈-번호}
close #{이슈-번호}
## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- WebSocket 연결 실패 원인을 해결하기 위해 CONNECT 프레임 인증 로직을 수정했습니다.
- SockJS fallback 시 access_token을 쿼리 파라미터로 전달하는 경우에도 인증이 가능하도록 처리했습니다.
- 배포 환경에서 WebSocket 및 SSE 통신 시 필요한 CORS 설정을 보완했습니다.
## 📝 PR 유형
어떤 변경 사항이 있나요?
## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 🗨️ 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->

<!-- 예시
resolves #{이슈-번호}
close #{이슈-번호}
## Feat
회원가입 기능 구현
## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
## 팀원에게 전할 말
- 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CORS 설정에서 허용되는 HTTP 메서드와 헤더가 명확하게 지정되어, 더 다양한 요청이 정상적으로 처리됩니다.
  * WebSocket 연결 시 토큰을 "Authorization" 또는 "access_token" 헤더에서 모두 인식할 수 있도록 개선되어, 인증 처리의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->